### PR TITLE
Fix broken word wrapping in toasts.

### DIFF
--- a/patcher/src/sass/character-creation/_character-creation.scss
+++ b/patcher/src/sass/character-creation/_character-creation.scss
@@ -195,4 +195,5 @@
   border: 1px rgba(255, 255, 255, 0.19) solid;
   outline-offset: 1px;
   outline: 5px solid rgba(0, 0, 0, 0.5);
+  word-break: normal;
 }


### PR DESCRIPTION
This fixes broken word wrapping splitting lines in the middle of a word.

I recommend further updates to the toast format, as well. The current position feels odd to me and makes it somewhat easy to miss. Personally, I would move it somewhere more obvious (either centered or closer to the 'CREATE' button). I would also make the colors contrast more so it's very clear that it's an error message the user needs to read.