### PR TITLE
Move attribute labels next to point value.

### DIFF
--- a/patcher/src/sass/character-creation/_attribute-select.scss
+++ b/patcher/src/sass/character-creation/_attribute-select.scss
@@ -5,41 +5,44 @@
  */
 
 .rightarrow, .leftarrow {
-    background: url("../images/arrow.png") no-repeat;
-    background-size: contain;
-    border: none;
-    display: inline-block;
-    height: 18px;
-    width: 18px;
-    &:focus{
-        background-color: transparent;
-    }
-    &:hover{
-        filter: brightness(150%);
-        -webkit-filter: brightness(150%);
-    }
+  background: url("../images/arrow.png") no-repeat;
+  background-size: contain;
+  border: none;
+  display: inline-block;
+  height: 18px;
+  width: 18px;
+  &:focus{
+    background-color: transparent;
+  }
+  &:hover{
+    filter: brightness(150%);
+    -webkit-filter: brightness(150%);
+  }
 }
 
 .leftarrow {
-    transform: rotate(180deg);
+  transform: rotate(180deg);
 }
 
 .attribute-points {
-    display: inline-block;
-    min-width: 30px;
-    text-align: center;
-    background: rgba(0, 0, 0, 0.5);
+  display: inline-block;
+  min-width: 30px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.5);
+  .label {
+    text-align: left;
+  }
 }
 
 .attribute-row{
-    width: 100%;
-    display: block;
-    background: linear-gradient(to bottom right, rgba(0, 0, 0, 0.5), transparent);
-    padding-bottom: 10px;
-    &:hover{
-      filter: brightness(150%);
-      -webkit-filter: brightness(150%);
-    }
+  width: 100%;
+  display: block;
+  background: linear-gradient(to bottom right, rgba(0, 0, 0, 0.5), transparent);
+  padding-bottom: 10px;
+  &:hover{
+    filter: brightness(150%);
+    -webkit-filter: brightness(150%);
+  }
 }
 
 .right {
@@ -51,9 +54,9 @@
 }
 
 span.points {
-    font-size: .8em;
-    font-family: 'TitilliumWeb';
-    color: rgb(206, 181, 59);
+  font-size: .8em;
+  font-family: 'TitilliumWeb';
+  color: rgb(206, 181, 59);
 }
 
 .attributes-view {
@@ -113,21 +116,19 @@ span.points {
 }
 
 @media screen and (max-width: 900px) {
-   .attributes-view .attribute-row{
+  .attributes-view .attribute-row{
     max-width: 100%;
   }
 }
 
 @media screen and (min-width: 1300px) {
-   .attributes-view .attribute-row{
+  .attributes-view .attribute-row{
     max-width: calc(33.33% - 10px);
   }
 }
 
-
 @media screen and (min-width: 1600px) {
-   .attributes-view .attribute-row{
+  .attributes-view .attribute-row{
     max-width: calc(25% - 10px);
   }
 }
-

--- a/patcher/src/ts/character-creation/components/AttributesSelect.tsx
+++ b/patcher/src/ts/character-creation/components/AttributesSelect.tsx
@@ -69,14 +69,16 @@ class AttributesSelect extends React.Component<AttributesSelectProps, Attributes
     let stringValue = info.units == 'units' ?  value : value.toFixed(4);
     return (
       <div key={info.name} className='attribute-row row'>
-        <div className='col s2 attribute-points'>
-          {stringValue}
+        <div className='attribute-points'>
+          <div className='col s10 label'>
+            {info.name} <i>({info.units})</i>
+          </div>
+          <div className='col s2'>
+            {stringValue}
+          </div>
         </div>
-        <div className='col s10'>
-        {info.name} <i>({info.units})</i>
         <div className='attribute-description'>
-        {info.description}
-        </div>
+          {info.description}
         </div>
       </div>
     )
@@ -115,11 +117,13 @@ class AttributesSelect extends React.Component<AttributesSelectProps, Attributes
         </div>
         <div className='view-content row attributes-view'>
           <div className='col s12'>
-            <h4>Primary</h4>
-            {primaries.map((a: AttributeInfo) => {
-              let offsetValue = offset == null ? 0 : typeof offset.attributeOffsets[a.name] === 'undefined' ? 0 : offset.attributeOffsets[a.name];
-              return this.generateAttributeView(a, a.baseValue + a.allocatedPoints + offsetValue);
-            })}
+            <div className='row'>
+              <h4>Primary</h4>
+              {primaries.map((a: AttributeInfo) => {
+                let offsetValue = offset == null ? 0 : typeof offset.attributeOffsets[a.name] === 'undefined' ? 0 : offset.attributeOffsets[a.name];
+                return this.generateAttributeView(a, a.baseValue + a.allocatedPoints + offsetValue);
+              })}
+            </div>
             <div className='row'>
               <h4>Secondary</h4>
               {secondaries.map((a: AttributeInfo) => {
@@ -128,11 +132,11 @@ class AttributesSelect extends React.Component<AttributesSelectProps, Attributes
               })}
             </div>
             <div className='row'>
-            <h4>Derived</h4>
-            {derived.map((a: AttributeInfo) => {
-              return this.generateAttributeView(a, this.calculateDerivedValue(a, offset));
-            })}
-          </div>
+              <h4>Derived</h4>
+              {derived.map((a: AttributeInfo) => {
+                return this.generateAttributeView(a, this.calculateDerivedValue(a, offset));
+              })}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
On the attributes screen, the labels are below the point values and it looks odd. This fixes that as well as fixes indentation in _attribute-select.scss.

I have no doubt Koo can improve this, but it looks better than what it was before.