### PR TITLE
Center pictures within the full-screen news articles

### DIFF
--- a/patcher/src/sass/_news.scss
+++ b/patcher/src/sass/_news.scss
@@ -173,8 +173,8 @@
         margin: auto;
         
         img {
-            height: auto;
-            max-width:100%;
+            display: block;
+            margin: 0 auto;
         }
       }
     }

--- a/patcher/src/sass/_news.scss
+++ b/patcher/src/sass/_news.scss
@@ -175,6 +175,8 @@
         img {
             display: block;
             margin: 0 auto;
+            height: auto;
+            max-width:100%;
         }
       }
     }


### PR DESCRIPTION
Both commits are me. I suck and didn't remember to replace the original css before pushing. 

Also had sent this to csegames/CU by mistake - closed that request and added it here.