### PR TITLE
Improve look of character attributes screen.

### DIFF
--- a/shared/widgets/CharacterCreation/components/AttributesSelect.tsx
+++ b/shared/widgets/CharacterCreation/components/AttributesSelect.tsx
@@ -66,17 +66,47 @@ class AttributesSelect extends React.Component<AttributesSelectProps, Attributes
   }
 
   generateAttributeView = (info: AttributeInfo, value: number) => {
-    let stringValue = info.units == 'units' ?  value : value.toFixed(4);
+    let stringValue: string = value.toFixed(4);
+    switch(info.units.toLowerCase()) {
+      case 'units':
+        stringValue = value.toString();
+        break;
+      case 'units/second':
+        stringValue = value.toFixed(4) + '/s';
+        break;
+      case 'years':
+        stringValue = Math.floor(value) + ' years';
+        break;
+      case 'percent':
+        stringValue = value.toFixed(1) + '%';
+        break;
+      case 'degrees celsius':
+        stringValue = value.toFixed(1) + ' °C';
+        break;
+      case 'kilograms':
+        stringValue = value.toFixed(1) + ' kg';
+        break;
+      case 'meters':
+        stringValue = value.toFixed(1) + ' m';
+        break;
+      case 'meters/second':
+        stringValue = value.toFixed(1) + ' m/s';
+        break;
+      default:
+        stringValue = value.toFixed(4);
+    }
     return (
       <div key={info.name} className='attribute-row row'>
-        <div className='col s2 attribute-points'>
-          {stringValue}
+        <div className='col s2 attribute-header'>
+          <div className='col s8 attribute-header-name'>
+            {info.name}
+          </div>
+          <div className='col s4 attribute-header-value'>
+            {stringValue}
+          </div>
         </div>
-        <div className='col s10'>
-        {info.name} <i>({info.units})</i>
-        <div className='attribute-description'>
-        {info.description}
-        </div>
+        <div className='col s10 attribute-description'>
+          {info.description}
         </div>
       </div>
     )

--- a/shared/widgets/CharacterCreation/sass/_attribute-select.scss
+++ b/shared/widgets/CharacterCreation/sass/_attribute-select.scss
@@ -5,41 +5,41 @@
  */
 
 .rightarrow, .leftarrow {
-    background: url("../images/arrow.png") no-repeat;
-    background-size: contain;
-    border: none;
-    display: inline-block;
-    height: 18px;
-    width: 18px;
-    &:focus{
-        background-color: transparent;
-    }
-    &:hover{
-        filter: brightness(150%);
-        -webkit-filter: brightness(150%);
-    }
+  background: url("../images/arrow.png") no-repeat;
+  background-size: contain;
+  border: none;
+  display: inline-block;
+  height: 18px;
+  width: 18px;
+  &:focus {
+    background-color: transparent;
+  }
+  &:hover {
+    filter: brightness(150%);
+    -webkit-filter: brightness(150%);
+  }
 }
 
 .leftarrow {
-    transform: rotate(180deg);
+  transform: rotate(180deg);
 }
 
 .attribute-points {
-    display: inline-block;
-    min-width: 30px;
-    text-align: center;
-    background: rgba(0, 0, 0, 0.5);
+  display: inline-block;
+  min-width: 30px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.5);
 }
 
-.attribute-row{
-    width: 100%;
-    display: block;
-    background: linear-gradient(to bottom right, rgba(0, 0, 0, 0.5), transparent);
-    padding-bottom: 10px;
-    &:hover{
-      filter: brightness(150%);
-      -webkit-filter: brightness(150%);
-    }
+.attribute-row {
+  width: 100%;
+  display: block;
+  background: linear-gradient(to bottom right, rgba(0, 0, 0, 0.5), transparent);
+  padding-bottom: 10px;
+  &:hover {
+    filter: brightness(150%);
+    -webkit-filter: brightness(150%);
+  }
 }
 
 .right {
@@ -51,9 +51,9 @@
 }
 
 span.points {
-    font-size: .8em;
-    font-family: 'TitilliumWeb';
-    color: rgb(206, 181, 59);
+  font-size: .8em;
+  font-family: 'TitilliumWeb';
+  color: rgb(206, 181, 59);
 }
 
 .attributes-view {
@@ -76,7 +76,7 @@ span.points {
     width: 100%;
     bottom: 195px;
   }
-  .attribute-row{
+  .attribute-row {
     max-width: calc(50% - 10px);
     display: inline-block;
     margin-right: 10px;
@@ -89,18 +89,23 @@ span.points {
       color:#e2e2e2;
     }
   }
-  .attribute-points{
-    padding: 10px 10px;
+  .attribute-header {
+    padding: 10px 3px;
     border-width: 1px;
     margin-bottom: 5px;
     border-image: linear-gradient(to bottom right, rgba(132, 132, 132, 0.32), transparent);
     border-image-slice: 1;
     min-width: 100%;
-    text-align: right;
     background: linear-gradient(to bottom right, rgba(0, 0, 0, 0.5), transparent);
     color: #C7AC8F;
+    .attribute-header-name {
+      text-align: left;
+    }
+    .attribute-header-value {
+      text-align: right;
+    }
   }
-  h4{
+  h4 {
     font-size:1.2em;
     text-transform: uppercase;
     padding-bottom: 5px;
@@ -113,21 +118,19 @@ span.points {
 }
 
 @media screen and (max-width: 900px) {
-   .attributes-view .attribute-row{
+  .attributes-view .attribute-row {
     max-width: 100%;
   }
 }
 
 @media screen and (min-width: 1300px) {
-   .attributes-view .attribute-row{
+  .attributes-view .attribute-row {
     max-width: calc(33.33% - 10px);
   }
 }
 
-
 @media screen and (min-width: 1600px) {
-   .attributes-view .attribute-row{
-    max-width: calc(25% - 10px);
+  .attributes-view .attribute-row {
+    max-width: calc(33.33% - 10px);
   }
 }
-


### PR DESCRIPTION
Based on feedback from JB, this is my second shot at improving the look of the character attributes screen. The attribute titles are now on the same line as the attribute values and units are converted into more friendly formats.

![clientpatcherui_2016-07-13_01-07-29](https://cloud.githubusercontent.com/assets/166781/16792460/b1b0f1da-4896-11e6-900c-cc02f8b93edb.jpg)
![clientpatcherui_2016-07-13_01-07-38](https://cloud.githubusercontent.com/assets/166781/16792463/b1b377ac-4896-11e6-851a-3358f2e69fff.jpg)
![clientpatcherui_2016-07-13_01-07-49](https://cloud.githubusercontent.com/assets/166781/16792462/b1b342d2-4896-11e6-9b7e-b927ff078d7d.jpg)
![clientpatcherui_2016-07-13_01-07-56](https://cloud.githubusercontent.com/assets/166781/16792461/b1b22b22-4896-11e6-84f7-b77d19aac404.jpg)
