### PR TITLE
Fixes the padding around the attributes in attribute distribution

### DIFF
--- a/shared/widgets/CharacterCreation/sass/_attribute-select.scss
+++ b/shared/widgets/CharacterCreation/sass/_attribute-select.scss
@@ -42,6 +42,11 @@
   }
 }
 
+.selection-box {
+  .attribute-row {
+    padding: 5px;
+  }
+}
 .right {
   float: right;
 }


### PR DESCRIPTION
![Old](https://cdn.discordapp.com/attachments/198226794900488192/202865541646385153/unknown.png)

The attribute-row styles currently set padding-bottom: 10px; which leaves the text with no left margin and the contents vertically positioned at the top.  This also means the text for the attributes are outdented from the title.

This fix sets padding to 5px all round.  Content is centered vertically, and the text has a margin, and is now slightly indented from the title.

![New](https://cdn.discordapp.com/attachments/198226794900488192/202865673217638400/unknown.png)