### PR TITLE
craftedabilities api requires https

### DIFF
--- a/library/src/restapi/RestAPI.ts
+++ b/library/src/restapi/RestAPI.ts
@@ -14,7 +14,7 @@ export function getMessageOfTheDay(){
 
 // TODO update this to use new Rest Client
 export function getCraftedAbilities(loginToken: string, characterID: string) {
-  return RestClientLegacy.getJSON('craftedabilities', false, {
+  return RestClientLegacy.getJSON('craftedabilities', true, {
     loginToken: loginToken,
     characterID: characterID
   });


### PR DESCRIPTION
Blocking me from resuming work on the skillbar, error when trying to load abilities:

Failed to load resource: the server responded with a status of 403 (HTTPS Required) http://hatchery.camelotunchained.com:8000/api/craftedabilities?loginToken=....&characterID=jNIArqMwM24xNLL7AxT100
error: HTTPS Required | response: [object Object]

