### PR TITLE
Save and restore UI positions & size as %

### DIFF
--- a/game/hud/src/index.tsx
+++ b/game/hud/src/index.tsx
@@ -17,7 +17,6 @@ import HUD from './components/HUD';
 let store = createStore(reducer, applyMiddleware(thunk));
 let root = document.getElementById('hud');
 
-
 // #TODO Reminder: export a 'has api' check from the camelot-unchained lib
 // interface for window cuAPI
 import cu, {client} from 'camelot-unchained';
@@ -37,7 +36,7 @@ if ((window.opener && window.opener.cuAPI) || window.cuAPI) {
         <HUD />
       </Provider>,
       root);
-  });  
+  });
 } else {
   initialize();
   ReactDom.render(

--- a/game/hud/src/services/session/layout.ts
+++ b/game/hud/src/services/session/layout.ts
@@ -101,10 +101,10 @@ export function adjustWidgetPositions() {
 
 const defaultWidgets = (): any => {
   return {
-    'PlayerHealth': { x: 100, y: 300, height: 200, width: 350, scale: 1 },
-    'TargetHealth': { x: 600, y: 300, height: 200, width: 350, scale: 1 },
-    'Warband': { x: 100, y: 10, scale:1, height: 200, width: 350 },
-    'Chat': { x: 10, y: 100, scale:1, height: 300, width: 600 },
+    'PlayerHealth': {x: 100, y: 300, height: 200, width: 350, scale: 1},
+    'TargetHealth': {x: 600, y: 300, height: 200, width: 350, scale: 1},
+    'Warband': {x: 100, y: 10, scale:1, height: 200, width: 350},
+    'Chat': {x: 10, y: 100, scale:1, height: 300, width: 600},
   };
 }
 


### PR DESCRIPTION
This change alters how the position (and size) of a HUD UI is persisted.  It is saved as a % or more accurately a fraction (between 0 and 1) representing the relative position and size in the window.  When restoring position (and size) the current window size is used, so that the UI element is restore to the same position at the new resolution.

However, I feel that this change on its own doesn't really solve any problems, the issues with it are:

1. if the window is resized, the UI elements are not adjusted and may now be off screen
2. scaling doesn't work well, at present this logic will adjust the pixel dimensions of the box for the UI, which creates its own set of issues with those UIs
3. the scroll wheel logic doesn't adjust the pixel dimensions, so a UI can't be expanded or shrunk

Ideally the HUD should handle resize events and scale/reposition UIs based on old and new size window.  Scaling should work, and leave the pixel size of he UI fixed.