### PR TITLE
DEBUG_ASSERT

### DIFF
--- a/library/src/core/core.ts
+++ b/library/src/core/core.ts
@@ -44,6 +44,8 @@ import LogMessage from './classes/LogMessage';
 import ChatMessage from './classes/ChatMessage';
 import ConsoleMessage from './classes/ConsoleMessage';
 
+import {DEBUG_ASSERT} from './utils/assert';
+
 export {
   // core
   CoreSettings,
@@ -81,4 +83,7 @@ export {
   LogMessage,
   ChatMessage,
   ConsoleMessage,
+
+  // misc
+  DEBUG_ASSERT
 }

--- a/library/src/core/utils/assert.ts
+++ b/library/src/core/utils/assert.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+export function DEBUG_ASSERT(test: any, reason: string) {
+  if (!test) {
+    const assert: string = 'DEBUG_ASSERT: ' + reason;
+    throw new Error(assert);
+  }
+}

--- a/library/src/core/utils/assert.ts
+++ b/library/src/core/utils/assert.ts
@@ -3,10 +3,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import client from '../client';
+
+declare const window: any;
+
+let debug: boolean;
+if (client) {
+  debug = client.debug;
+} else if (window.patcherAPI) {
+  debug = window.patcherAPI.debug;
+} else {
+  debug = true;
+}
 
 export function DEBUG_ASSERT(test: any, reason: string) {
-  if (!test) {
-    const assert: string = 'DEBUG_ASSERT: ' + reason;
-    throw new Error(assert);
+  if (!test && debug) {
+    throw new Error('DEBUG_ASSERT: ' + reason);
   }
 }

--- a/library/src/index.ts
+++ b/library/src/index.ts
@@ -57,6 +57,7 @@ import events from './events';
 import * as eventExports from './events'
 
 import signalr from './signalr';
+import {DEBUG_ASSERT} from './core/core';
 
 export * from './slashCommands';
 import * as slashCommandsExports from './slashCommands';
@@ -156,5 +157,7 @@ export {
   // RestAPI
   restAPI,
 
+  // misc
   signalr,
+  DEBUG_ASSERT
 }


### PR DESCRIPTION
Adds a DEBUG_ASSERT function to camelot-unchained library.

**Usage**

````javascript
import {DEBUG_ASSERT} from 'camelot-unchained';

export function doSomethingWithState(state: SomeState) {
  DEBUG_ASSERT(state, 'state undefined in doSomethingWithState');
  // now do something with it
}
```

````javascript
import {DEBUG_ASSERT} from 'camelot-unchained';

render() {
  const widget: any = this.props.widget[this.props.name];
  DEBUG_ASSERT(widget, 'widget ' + this.props.name + ' is undefined in SomeComponent:render()');
  // rest assured, widget is now defined
}
```

Use DEBUG_ASSERT to ensure that a variable or parameter is what you would expect it any given point.  Use of DEBUG_ASSERT will help find bugs more quickly and closer to where they happen making it easier to track down the cause.

They can also be a helpful tool when debugging a problem.

**Console Output**

    + Uncaught Error: DEBUG_ASSERT: widget Chat is undefined in HUD:render()

In the chrome debugger, you can expand the + to get a stack trace (but its often not very meaningful) so the text of the assert can be used to help locate it.


