### PR TITLE
Fix positioning when minimised & cleanup obsolete code

### DIFF
--- a/game/hud/src/components/HUD/index.tsx
+++ b/game/hud/src/components/HUD/index.tsx
@@ -10,7 +10,7 @@ let Draggable = require('react-draggable');
 import {client, GroupInvite} from 'camelot-unchained';
 import Chat from 'cu-xmpp-chat';
 
-import {LayoutState, Position, lockHUD, unlockHUD, savePosition, initialize, adjustWidgetPositions} from '../../services/session/layout';
+import {LayoutState, Position, lockHUD, unlockHUD, savePosition, initialize} from '../../services/session/layout';
 import {HUDSessionState} from '../../services/session/reducer';
 
 import Crafting from '../../widgets/Crafting';

--- a/game/hud/src/services/session/layout.ts
+++ b/game/hud/src/services/session/layout.ts
@@ -17,7 +17,6 @@ const UNLOCK_HUD = 'hud/layout/UNLOCK_HUD';
 const SET_POSITION = 'hud/layout/SET_POSITION';
 const SAVE_POSITION = 'hud/layout/SAVE_POSITION';
 const RESET_POSITIONS = 'hud/layout/RESET_POSITIONS';
-const ADJUST_POSITIONS = 'hud/layout/ADJUST_POSITIONS';
 
 const ON_RESIZE = 'hud/layout/ON_RESIZE';
 
@@ -103,13 +102,6 @@ export function saySomething(s: string) : LayoutAction {
     type: SAY_SOMETHING,
   }
 }
-
-export function adjustWidgetPositions() {
-  return {
-    type: ADJUST_POSITIONS,
-  }
-}
-
 
 const defaultWidgets = (): any => {
   return {
@@ -288,18 +280,6 @@ export default function reducer(state: LayoutState = getInitialState(),
       outState = Object.assign({}, state, {
         widgets: widgets
       });
-      break;
-    case ADJUST_POSITIONS:
-      // need to scan wiget positions, and check if they still fit in the
-      // new window size
-      const screen: Size = { width: window.innerWidth, height: window.innerHeight };
-      widgets = {};
-      for (let key in state.widgets) {
-        widgets[key] = forceOnScreen(Object.assign({}, state.widgets[key]), screen);
-      }
-      outState = Object.assign({}, state, {
-        widgets: widgets
-      })
       break;
     case ON_RESIZE:
     {


### PR DESCRIPTION
Fixes the case where minimising the client window causes UIs to be sized to 1x1 pixels.

Also, removes some obsolete positioning code.