### PR TITLE
bug fixes and improvements to the recently used pane

### DIFF
--- a/game/building/src/lib/BuildingItem.ts
+++ b/game/building/src/lib/BuildingItem.ts
@@ -13,6 +13,7 @@ export enum BuildingItemType {
 export interface BuildingItem {
   id: string
   type: BuildingItemType,
+  matElement: JSX.Element,
   element: JSX.Element,
   name: string,
   description: string

--- a/game/building/src/widgets/BuildPanel/widgets/Blocks/components/MaterialAndShapePane/index.tsx
+++ b/game/building/src/widgets/BuildPanel/widgets/Blocks/components/MaterialAndShapePane/index.tsx
@@ -40,7 +40,7 @@ export interface MaterialAndShapePaneState {
 class MaterialAndShapePane extends React.Component<MaterialAndShapePaneProps, MaterialAndShapePaneState> {
 
   private blockSelectionListener = (info: { material: BuildingMaterial, block: BuildingBlock }) => {
-    this.onBlockSelect(info.block);
+    this.onBlockSelect(info.material, info.block);
   }
 
 
@@ -49,15 +49,16 @@ class MaterialAndShapePane extends React.Component<MaterialAndShapePaneProps, Ma
     this.state = { showMatSelect: false };
   }
 
-  onBlockSelect = (block: BuildingBlock) => {
+  onBlockSelect = (material: BuildingMaterial, block: BuildingBlock) => {
     if (block != null) {
       const item = {
         name: block.shapeId + ". " + block.shapeTags.join(', '),
         description: block.materialId + ". " + block.materialTags.join(', '),
+        matElement: (<img src={'data:image/png;base64,' + material.icon}/>),
         element: (<img src={'data:image/png;base64,' + block.icon}/>),
-        id: block.id + '-' + BuildingItemType.Block,
+        id: material.id + '-' + BuildingItemType.Block,
         type: BuildingItemType.Block,
-        select: () => { this.selectBlock(block) }
+        select: () => { this.selectMaterial(material) }
       } as BuildingItem;
       fireBuildingItemSelected(item);
     } else {

--- a/game/building/src/widgets/BuildPanel/widgets/Blueprints/components/BlueprintsPane/index.tsx
+++ b/game/building/src/widgets/BuildPanel/widgets/Blueprints/components/BlueprintsPane/index.tsx
@@ -46,6 +46,9 @@ class BlueprintsPane extends React.Component<BlueprintsPaneProps, BlueprintsPane
   }
 
   onBlueprintSelect = (blueprint: BuildingBlueprint) => {
+    if (blueprint != null && blueprint.icon == null)
+      blueprintService.loadIcon(blueprint);
+
     const item = {
       name: "Blueprint",
       description: blueprint.name,

--- a/game/building/src/widgets/BuildPanel/widgets/DropLight/components/DroplightPane/index.tsx
+++ b/game/building/src/widgets/BuildPanel/widgets/DropLight/components/DroplightPane/index.tsx
@@ -87,6 +87,7 @@ class DropLightPane extends React.Component<DropLightPaneProps, DropLightPaneSta
 
   selectLight = (light: Light) => {
     this.props.dispatch(lightService.selectLight(light));
+    this.selectLightAsBuildingItem(light);
   }
 
   triggerClear = () => {

--- a/game/building/src/widgets/BuildPanel/widgets/DropLight/components/LightSelector/index.tsx
+++ b/game/building/src/widgets/BuildPanel/widgets/DropLight/components/LightSelector/index.tsx
@@ -52,7 +52,7 @@ class LightSelector extends React.Component<LightSelectorProps, LightSelectorSta
         element: (<LightPreview light={light} />),
         id: light.index + '-' + BuildingItemType.Droplight,
         type: BuildingItemType.Droplight,
-        select: () => { this.props.dispatch(lightService.selectLight(light)) }
+        select: () => { this.selectLight(light) }
       } as BuildingItem;
     }
     fireBuildingItemSelected(item);
@@ -60,10 +60,6 @@ class LightSelector extends React.Component<LightSelectorProps, LightSelectorSta
 
   selectLight = (light: Light) => {
     this.props.dispatch(lightService.selectLight(light));
-  }
-
-  selectLightAndNotify = (light: Light) => {
-    this.selectLight(light);
     this.selectLightAsBuildingItem(light);
   }
 
@@ -81,7 +77,7 @@ class LightSelector extends React.Component<LightSelectorProps, LightSelectorSta
       <div key={'preset' + light.index} className="preset-light">
         <LightPreview
           className={selected ? 'active' : ''}
-          selectLight={this.selectLightAndNotify}
+          selectLight={this.selectLight}
           light={light} />
         <div>{light.presetName}</div>
       </div>

--- a/game/building/src/widgets/BuildPanel/widgets/RecentSelections/components/RecentSelections.tsx
+++ b/game/building/src/widgets/BuildPanel/widgets/RecentSelections/components/RecentSelections.tsx
@@ -49,15 +49,15 @@ class RecentSelections extends React.Component<RecentSelectionsProps, RecentSele
     const selection = this.props.item;
 
     return (
-        <div className={`recent-selections ${this.props.minimized ? 'minimized' : ''}`}>
-          { this.props.items.map((item: BuildingItem, index: number) => {
-            if (item == null)
-              return (<span key={'empty' + index}  className='icon'></span>)
-            return (<span key={item.id}  className={this.isSelectedItem(item, selection) ? 'active icon' : 'icon'}
-              onClick={() => this.selectItem(item) } >{item.element}</span>)
-          })
-          }
-        </div>
+      <div className={`recent-selections ${this.props.minimized ? 'minimized' : ''}`}>
+        { this.props.items.map((item: BuildingItem, index: number) => {
+          if (item == null)
+            return (<span key={'empty' + index}  className='icon'></span>)
+          return (<span key={item.id}  className={this.isSelectedItem(item, selection) ? 'active icon' : 'icon'}
+            onClick={() => this.selectItem(item) } >{item.matElement ? item.matElement : item.element}</span>)
+        })
+        }
+      </div>
     )
   }
 }

--- a/game/building/src/widgets/BuildPanel/widgets/RecentSelections/index.scss
+++ b/game/building/src/widgets/BuildPanel/widgets/RecentSelections/index.scss
@@ -17,6 +17,7 @@
     width: 30px;
     overflow: hidden;
     transition: all .1s ease-in-out;
+    margin: 1px;
 
     &:hover {
       filter: brightness(120%);


### PR DESCRIPTION
Droplights now show up in the recently used pane again.
Blueprints will not have broken images when displayed in the recently used pane.
The recently used pane now works off materials instead of blocks, usability suggestion from Necromaniak. 