### PR TITLE
Fix positioning scaled widgets

### DIFF
--- a/game/hud/src/components/HUD/index.tsx
+++ b/game/hud/src/components/HUD/index.tsx
@@ -90,8 +90,6 @@ class HUD extends React.Component<HUDProps, HUDState> {
 
     const factor = e.altKey ? 0.01 : 0.10;
 
-    console.log(e.nativeEvent.deltaY);
-
     const pos: Position = this.props.layout.widgets[name];
 
     if (e.nativeEvent.deltaY < 0) {

--- a/game/hud/src/services/session/layout.ts
+++ b/game/hud/src/services/session/layout.ts
@@ -188,13 +188,19 @@ function anchored2position(anchored: AnchoredPosition, screen: Size) : Position 
 }
 
 function forceOnScreen(current: Position, screen: Size) : Position {
+  // If the UI is scaled, it is being scaled around the center, so for example, a widget that
+  // is 200 pixels wide, scaled to 0.5 and positioned at the edge of the screen, the x position
+  // is actually -50px.  ie -((width/2)*scale), so we need to work out the margin amount based
+  // on the scale amount.
+  const xmargin: number = (current.width/2)*current.scale;
+  const ymargin: number = (current.height/2)*current.scale;
   const pos: Position = Object.assign({}, current);
-  if (pos.x < 0) pos.x = 0;
-  if (pos.y < 0) pos.y = 0;
-  if (pos.x + pos.width > screen.width) pos.x = screen.width - pos.width;
-  if (pos.y + pos.height > screen.height) pos.y = screen.height - pos.height;
-  if (pos.x < 0) { pos.x = 0; pos.width = screen.width; }
-  if (pos.y < 0) { pos.y = 0; pos.height = screen.height; }
+  if (pos.x < -xmargin) pos.x = -xmargin;
+  if (pos.y < -ymargin) pos.y = -ymargin;
+  if (pos.x + pos.width > screen.width + xmargin) pos.x = screen.width - pos.width + xmargin;
+  if (pos.y + pos.height > screen.height + ymargin) pos.y = screen.height - pos.height + ymargin;
+  if (pos.x < -xmargin) { pos.x = -xmargin; pos.width = screen.width + xmargin; }
+  if (pos.y < -ymargin) { pos.y = -ymargin; pos.height = screen.height + ymargin; }
   return pos;
 }
 


### PR DESCRIPTION
There was an issue with positioning of scaled widgets, particularly noticeable with widgets scaled below 1.0 but the same issue exists for widgets scaled above 1.0.  It seems that (don't know if this intentional or not) the div for the widget is scaled around the center point, so the left and right top and bottom edges all move inwards.

This means that if we shrink a widget below 1.0, and then move that widget to butt up against the screen edge, the co-ordinates of that widget now overlap the edge of the screen.  The forceOnScreen() logic comes along and moves it back on screen, which means the widget now has a gap between it and the screen edge.

The fix is to calculate the screen margin (the amount of pixels a UI is allowed to overlap the edge of the screen) based on the current widgets position, size and scale.  So for example, we have a widget that is 200 pixels wide, scaled to 0.5 (1/2 size) and moved to the left edge of the screen.  The x position is now -50px or -((width/2)*0.5).

This PR updates forceOnScreen() to allow for the margin of overlap (or underlap), which corrects the issue.