### PR TITLE
Fixed positioning on resize, also fix loading saved position

### DIFF
--- a/game/hud/src/components/HUD/index.tsx
+++ b/game/hud/src/components/HUD/index.tsx
@@ -97,6 +97,7 @@ class HUD extends React.Component<HUDProps, HUDState> {
       this.props.dispatch(savePosition(name, {
         x: pos.x,
         y: pos.y,
+        anchor: pos.anchor,
         width: pos.width,
         height: pos.height,
         scale: pos.scale - factor
@@ -105,6 +106,7 @@ class HUD extends React.Component<HUDProps, HUDState> {
       this.props.dispatch(savePosition(name, {
         x: pos.x,
         y: pos.y,
+        anchor: pos.anchor,
         width: pos.width,
         height: pos.height,
         scale: pos.scale + factor
@@ -124,7 +126,7 @@ class HUD extends React.Component<HUDProps, HUDState> {
                   onDrag={this.handleDrag}
                   onStop={(e:any, ui:any) => {
                     this.onStop();
-                    this.props.dispatch(savePosition(name, {x: ui.x, y: ui.y, width: pos.width, height: pos.height, scale: pos.scale}));
+                    this.props.dispatch(savePosition(name, {x: ui.x, y: ui.y, anchor: pos.anchor, width: pos.width, height: pos.height, scale: pos.scale}));
                   }}>
         <div>
           <div className={containerClass}
@@ -188,7 +190,7 @@ class HUD extends React.Component<HUDProps, HUDState> {
         {this.draggableWidget('PlayerHealth', widgets, PlayerHealth, 'player-health', {})}
         {this.draggableWidget('EnemyTargetHealth', widgets, EnemyTargetHealth, 'target-health', {})}
         {this.draggableWidget('FriendlyTargetHealth', widgets, FriendlyTargetHealth, 'target-health', {})}
-        
+
         <div className={`HUD__toggle ${locked ? 'HUD__toggle--locked': 'HUD__toggle--unlocked'} hint--top-left hint--slide`}
              onClick={e => this.onToggleClick(e)}
              data-hint={locked ? 'unlock hud | alt+click to reset': 'lock hud | alt+click to reset'}></div>

--- a/game/hud/src/services/session/layout.ts
+++ b/game/hud/src/services/session/layout.ts
@@ -271,7 +271,7 @@ function forceOnScreen(current: Position, screen: Size) : Position {
 
 function getInitialState(): any {
   const storedState: LayoutState = loadState();
-  if (storedState.widgets && storedState.widgets.length > 0) {
+  if (storedState) {
     storedState.locked = initialState().locked;
     return storedState;
   }
@@ -291,8 +291,8 @@ function loadState(state: LayoutState =  JSON.parse(localStorage.getItem(localSt
           state.widgets[key] = forceOnScreen(anchored2position(clone((initialState().widgets as any)[key]), screen), screen);
         }
       }
+      return state;
     }
-    return state;
   }
 }
 


### PR DESCRIPTION
1. Fixes the issue where resizing re-evaluated a widgets anchor point.  Now, the anchor point is only ever evaluated when a widget has just been dragged (ie in SAVE_POSITION)

2. Fixes an issue where widget positions were not being persisted correctly (specifically, they were not being loaded correctly, always being overridden by the default positions).