### PR TITLE
Work around initial login char select issues

### DIFF
--- a/patcher/src/ts/redux/modules/channels.ts
+++ b/patcher/src/ts/redux/modules/channels.ts
@@ -20,7 +20,6 @@ export function changeChannel(channel: Channel): any {
 
 export function requestChannels(selectedChannelID?: number): any {
   let channels = patcher.getAllChannels();
-  console.log(channels);
   if (channels == null || typeof(channels) == 'undefined') channels = <Array<Channel>>[];
 
   return {
@@ -54,7 +53,6 @@ export default function reducer(state: ChannelState = initialState, action: any 
       } else if (state.selectedChannel) {
         selectedChannel = action.channels.find((c:Channel) => c.channelID == state.selectedChannel.channelID);
       }
-      console.log(selectedChannel);
       return Object.assign({}, state, {
         channels: action.channels,
         selectedChannel: selectedChannel

--- a/patcher/src/ts/sidebar/PatchButton.tsx
+++ b/patcher/src/ts/sidebar/PatchButton.tsx
@@ -20,7 +20,13 @@ import {ServersState} from '../redux/modules/servers';
 import {ChannelState, requestChannels} from '../redux/modules/channels';
 import {CharactersState} from '../redux/modules/characters';
 
-
+//This should probably live elsewhere, maybe it already does?
+enum ChannelID {
+    Hatchery = 4,
+    Wyrmling = 10,
+    WyrmlingPrep = 11,
+    CUBE = 27
+}
 
 export class Progress {
   constructor(public rate: number = 0, public dataCompleted: number = 0, public totalDataSize: number = 0) { }
@@ -200,6 +206,7 @@ class PatchButton extends React.Component<PatchButtonProps, PatchButtonState> {
     );
   }
 
+  //The CC on this function is getting out of control it needs to be broken up
   render() {
     let uninstall: any = null;
     let layer1: any = null;
@@ -259,12 +266,12 @@ class PatchButton extends React.Component<PatchButtonProps, PatchButtonState> {
           videoElements[vid].play();
         }
 
-        function isGameChannel(id: number) {
-          return id === 4 || id === 10 || id === 11;
-        }
-
-        if (this.props.charactersState.characters.length == 0 || !this.props.charactersState.selectedCharacter && isGameChannel(this.props.channelsState.selectedChannel.channelID)) {
-          layer1 = <div className='waves-effect btn install-download-btn installing'>Select Character</div>;
+        if (this.props.channelsState.selectedChannel.channelID !== ChannelID.CUBE && !this.props.charactersState.selectedCharacter) {
+            if (this.props.charactersState.characters.length == 0 || this.props.charactersState.characters.filter( c => c.shardID == this.props.serversState.currentServer.shardID).length == 0) {
+              layer1 = <div className='waves-effect btn install-download-btn installing'>Create Character</div>;
+            } else {
+              layer1 = <div className='waves-effect btn install-download-btn installing'>Select Character</div>;
+            }
         } else {
           layer1 = <a className='waves-effect btn install-download-btn ready' onClick={this.onClicked.bind(event) }>Play Now</a>;
         }

--- a/patcher/src/ts/sidebar/ServerSelect.tsx
+++ b/patcher/src/ts/sidebar/ServerSelect.tsx
@@ -16,7 +16,6 @@ import {fetchCharacters, selectCharacter, CharactersState} from '../redux/module
 
 import Animate from '../../lib/Animate';
 
-
 export enum ServerStatus {
   OFFLINE,
   ONLINE,

--- a/patcher/src/ts/sidebar/ServerSelect.tsx
+++ b/patcher/src/ts/sidebar/ServerSelect.tsx
@@ -6,16 +6,17 @@
 
 import * as React from 'react';
 import {connect} from 'react-redux';
-
+import {restAPI} from 'camelot-unchained';
 import {Channel, ChannelStatus, patcher} from '../api/patcherAPI';
 import {Server, AccessType} from '../redux/modules/servers';
 import * as events from '../../lib/events';
 
 import {changeChannel, requestChannels, ChannelState} from '../redux/modules/channels';
 import {fetchServers, changeServer, ServersState} from '../redux/modules/servers';
-import {fetchCharacters, selectCharacter} from '../redux/modules/characters';
+import {fetchCharacters, selectCharacter, CharactersState} from '../redux/modules/characters';
 
 import Animate from '../../lib/Animate';
+
 
 export enum ServerStatus {
   OFFLINE,
@@ -26,7 +27,8 @@ export enum ServerStatus {
 function select(state: any): any {
   return {
     channelsState: state.channels,
-    serversState: state.servers
+    serversState: state.servers,
+    charactersState: state.characters
   }
 }
 
@@ -34,6 +36,7 @@ export interface SelectServerProps {
   dispatch?: (action: any) => void;
   channelsState?: ChannelState;  
   serversState?: ServersState;
+  charactersState?: CharactersState;
 }
 
 export interface SelectServerState {
@@ -52,6 +55,8 @@ class SelectServer extends React.Component<SelectServerProps, SelectServerState>
     this.state = {
       showList: false,
     };
+
+    
   }
 
   renderList() {
@@ -62,6 +67,13 @@ class SelectServer extends React.Component<SelectServerProps, SelectServerState>
     )
   }
 
+  trySelectCharacter = (shardID:number) => {
+    if(!this.props.charactersState || !this.props.charactersState.characters || 0 == this.props.charactersState.characters.length) return;
+
+    let filteredCharacters = this.props.charactersState.characters.filter( c => c.shardID == shardID);
+    if(filteredCharacters && filteredCharacters.length > 0) this.props.dispatch(selectCharacter(filteredCharacters[0]));
+  }
+
   onSelectedServerChanged = (server: any) => {
     const {dispatch} = this.props;
 
@@ -70,8 +82,8 @@ class SelectServer extends React.Component<SelectServerProps, SelectServerState>
     //is there a required order here?
     dispatch(changeChannel(server.channelInfo));
     dispatch(changeServer(server.serverInfo));
-    dispatch(fetchCharacters());
-    dispatch(selectCharacter(null));
+    if(server && server.shardID) this.trySelectCharacter(server.shardID);
+    else dispatch(selectCharacter(null));
     dispatch(fetchServers());
     dispatch(requestChannels());
     this.setState({
@@ -144,6 +156,11 @@ class SelectServer extends React.Component<SelectServerProps, SelectServerState>
     const {channels} = this.props.channelsState;
 
     if (!servers && !channels) return null;
+
+    //hack, sort out selected characters/servers/channels here until the underlying store gets sorted out
+    if(!this.props.charactersState.selectedCharacter && this.props.serversState.currentServer) {
+      this.trySelectCharacter(this.props.serversState.currentServer.shardID);
+    }
 
     this.listAsArray = this.mergeServerChannelLists(servers, channels);
 

--- a/patcher/src/ts/sidebar/ServerSelect.tsx
+++ b/patcher/src/ts/sidebar/ServerSelect.tsx
@@ -6,7 +6,6 @@
 
 import * as React from 'react';
 import {connect} from 'react-redux';
-import {restAPI} from 'camelot-unchained';
 import {Channel, ChannelStatus, patcher} from '../api/patcherAPI';
 import {Server, AccessType} from '../redux/modules/servers';
 import * as events from '../../lib/events';
@@ -55,8 +54,6 @@ class SelectServer extends React.Component<SelectServerProps, SelectServerState>
     this.state = {
       showList: false,
     };
-
-    
   }
 
   renderList() {


### PR DESCRIPTION
A "bunch of bullshit" to get around users having to select a character (that already appears to be selected) to get the play button to light up. The store need to be consolidated (working on that) currently its race condition/synchronization hell. I should be able to flush this code once the store gets sorted out. But I figured a few kludges are worth it now, been seeing login issues/complaints on the forums.

Note: it still has the 30's delay lameness, What is the cost of making this call(patcherAPI.ts line 118):

public getAllChannels() : Channel[] {
    if (this._api.channelData) {
      return Array.prototype.slice.call(this._api.channelData).sort(function(a:Channel, b:Channel) {
        return this.getChannelValue(a) - this.getChannelValue(b);
      }.bind(this));
    }
    return [];
  }

Does that result in a web request or just bounce off the client? How bad would it be to call this every second or so?