### PR TITLE
Fixed anchors

### DIFF
--- a/game/hud/src/components/AnchorIndicator/index.scss
+++ b/game/hud/src/components/AnchorIndicator/index.scss
@@ -1,0 +1,51 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+ $indicator-radius: 8px;
+ $grid-size: 60px;
+
+.AnchorIndicator-main {
+  position: absolute;
+  z-index: 10000;
+  left: calc(50% - #{$grid-size / 2});
+  top: calc(50% - #{$grid-size / 2});
+  height: $grid-size;
+  width: $grid-size;
+
+  >div.anchor {
+    width: $indicator-radius * 2;
+    height: $indicator-radius * 2;
+    border-radius: $indicator-radius;
+    background-color: rgba(0, 0, 0, 0.5);
+    position: absolute;
+    cursor: pointer;
+    &.x-axis-start {
+      left: 0;
+    }
+    &.x-axis-center {
+      left: calc(50% - #{$indicator-radius});
+    }
+    &.x-axis-end {
+      right: 0;
+    }
+    &.y-axis-start {
+      top: 0;
+    }
+    &.y-axis-center {
+      top: calc(50% - #{$indicator-radius});
+    }
+    &.y-axis-end {
+      bottom: 0;
+    }
+
+    &.current {
+      background-color: limegreen;
+    }
+    &.locked {
+      background-color: magenta;
+    }
+  }
+}

--- a/game/hud/src/components/AnchorIndicator/index.tsx
+++ b/game/hud/src/components/AnchorIndicator/index.tsx
@@ -54,7 +54,7 @@ class AnchorIndicator extends React.Component<AnchorIndicatorProps, AnchorIndica
         const classNames: string[] = [ 'anchor' ];
         classNames.push(x < 0 ? 'x-axis-start' : x > 0 ? 'x-axis-end' : 'x-axis-center');
         classNames.push(y < 0 ? 'y-axis-start' : y > 0 ? 'y-axis-end' : 'y-axis-center');
-        if (pos.anchor.x === x && pos.anchor.y === y) {
+        if (pos && pos.anchor && pos.anchor.x === x && pos.anchor.y === y) {
           classNames.push('current');
           if (pos.anchor.locked) classNames.push('locked');
         }

--- a/game/hud/src/components/AnchorIndicator/index.tsx
+++ b/game/hud/src/components/AnchorIndicator/index.tsx
@@ -1,0 +1,72 @@
+
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import * as React from 'react';
+import {Position} from '../../services/session/layout';
+
+export interface AnchorIndicatorProps {
+  name: string;     // widget name
+  pos: Position;    // current widget position
+  setAnchor: (name: string, pos: Position) => void;
+}
+
+export interface AnchorIndicatorState {
+}
+
+class AnchorIndicator extends React.Component<AnchorIndicatorProps, AnchorIndicatorState> {
+
+  constructor(props: AnchorIndicatorProps) {
+    super(props);
+  }
+
+  private anchorHere = (event: React.MouseEvent) => {
+    const el: HTMLDivElement = event.currentTarget as HTMLDivElement;
+    function a2n(a: string) : number {
+      switch(a) {
+        case 's': return -1;
+        case 'e': return 1;
+      }
+      return 0;
+    }
+    const pos: Position = Object.assign({}, this.props.pos);
+    let x: number = a2n(el.classList[1][7]);
+    let y: number = a2n(el.classList[2][7]);
+    if (x === pos.anchor.x && y === pos.anchor.y) {
+      pos.anchor.locked = !pos.anchor.locked;
+    } else {
+      pos.anchor.locked = true;
+      pos.anchor.x = x;
+      pos.anchor.y = y;
+    }
+    this.props.setAnchor(this.props.name, pos);
+  }
+
+  render() {
+    const anchors: JSX.Element[] = [];
+    const pos: Position = this.props.pos;
+    let key: number = 0;
+    for (var x = -1; x < 2; x++) {
+      for (let y: number = -1; y < 2; y++) {
+        const classNames: string[] = [ 'anchor' ];
+        classNames.push(x < 0 ? 'x-axis-start' : x > 0 ? 'x-axis-end' : 'x-axis-center');
+        classNames.push(y < 0 ? 'y-axis-start' : y > 0 ? 'y-axis-end' : 'y-axis-center');
+        if (pos.anchor.x === x && pos.anchor.y === y) {
+          classNames.push('current');
+          if (pos.anchor.locked) classNames.push('locked');
+        }
+        anchors.push(<div key={key++} className={classNames.join(' ')} onClick={this.anchorHere}/>);
+      }
+    }
+    return (
+      <div className="AnchorIndicator-main">
+        {anchors}
+      </div>
+    );
+  }
+}
+
+export default AnchorIndicator;

--- a/game/hud/src/components/HUD/index.tsx
+++ b/game/hud/src/components/HUD/index.tsx
@@ -20,6 +20,7 @@ import FriendlyTargetHealth from '../../widgets/FriendlyTargetHealth';
 import Warband from '../../widgets/Warband';
 import Respawn from '../../widgets/Respawn';
 import InviteAlert from '../InviteAlert';
+import AnchorIndicator from '../AnchorIndicator';
 
 function select(state: HUDSessionState): HUDProps {
   return {
@@ -133,12 +134,18 @@ class HUD extends React.Component<HUDProps, HUDState> {
     }
   }
 
+  private setAnchor = (name: string, pos: Position) => {
+    this.props.dispatch(savePosition(name, pos));
+  }
+
   draggableWidget = (name: string, widgets: any, Widget: any, containerClass: string, props?: any) => {
     const pos: Position = widgets[name];
 
     let dragHandle: any = null;
+    let anchor: JSX.Element = null;
     if (!this.props.layout.locked) {
       dragHandle = <div className={`drag-handle`}><h1>{name}</h1></div>;
+      anchor = <AnchorIndicator name={name} pos={pos} setAnchor={this.setAnchor}/>
     }
 
     return (
@@ -164,6 +171,7 @@ class HUD extends React.Component<HUDProps, HUDState> {
                onWheel={(e: any) => this.onWheel(name, e)}>
             <Widget {...props} />
             {dragHandle}
+            {anchor}
           </div>
         </div>
       </Draggable>

--- a/game/hud/src/index.scss
+++ b/game/hud/src/index.scss
@@ -27,6 +27,7 @@ html, body {
 @import './components/ClassIcon/index';
 @import './components/ActiveEffectIcon/index';
 @import './components/InviteAlert/index';
+@import './components/AnchorIndicator/index';
 
 // widgets
 @import './widgets/Crafting/index';

--- a/game/hud/src/services/session/layout.ts
+++ b/game/hud/src/services/session/layout.ts
@@ -78,6 +78,9 @@ export function resetHUD(): LayoutAction {
 }
 
 export function savePosition(name: string, pos: Position): LayoutAction {
+  DEBUG_ASSERT(name, 'savePosition: name argument required');
+  DEBUG_ASSERT(pos, 'savePosition: pos argument required');
+  DEBUG_ASSERT(pos.anchor, 'savePosition: pos missing anchor');
   return {
     type: SAVE_POSITION,
     widget: name,

--- a/game/hud/src/services/session/layout.ts
+++ b/game/hud/src/services/session/layout.ts
@@ -45,13 +45,8 @@ export interface LayoutAction {
 export interface Anchor {
   x: AxisAnchorRelativeTo;
   y: AxisAnchorRelativeTo;
+  locked: boolean;
 }
-
-const TOP_LEFT: Anchor = { x: AxisAnchorRelativeTo.START, y: AxisAnchorRelativeTo.START };
-const BOTTOM_LEFT: Anchor = { x: AxisAnchorRelativeTo.START, y: AxisAnchorRelativeTo.END };
-const TOP_RIGHT: Anchor = { x: AxisAnchorRelativeTo.END, y: AxisAnchorRelativeTo.START };
-const BOTTOM_RIGHT: Anchor = { x: AxisAnchorRelativeTo.END, y: AxisAnchorRelativeTo.END };
-const MIDDLE_OF_WINDOW: Anchor = { x: AxisAnchorRelativeTo.CENTER, y: AxisAnchorRelativeTo.CENTER };
 
 export interface Position {
   x: number;
@@ -147,11 +142,11 @@ const initialState = () => {
     reset: FORCE_RESET_CODE,
     locked: true,
     widgets: {
-      Chat:{x:{anchor:-1,px:0},y:{anchor:1,px:302},size:{width:480,height:240},scale:1},
-      PlayerHealth:{x:{anchor:0,px:-294},y:{anchor:1,px:315},size:{width:350,height:200},scale:0.6},
-      EnemyTargetHealth:{x:{anchor:0,px:-18},y:{anchor:1,px:315},size:{width:350,height:200},scale:0.6},
-      FriendlyTargetHealth:{x:{anchor:0,px:-18},y:{anchor:1,px:195},size:{width:350,height:200},scale:0.6},
-      Respawn:{x:{anchor:0,px:-100},y:{anchor:0,px:-100},size:{width:200,height:200},scale:1},
+      Chat:{x:{anchor:-1,px:0},y:{anchor:1,px:302},locked:false,size:{width:480,height:240},scale:1},
+      PlayerHealth:{x:{anchor:0,px:-294},y:{anchor:1,px:315},locked:false,size:{width:350,height:200},scale:0.6},
+      EnemyTargetHealth:{x:{anchor:0,px:-18},y:{anchor:1,px:315},locked:false,size:{width:350,height:200},scale:0.6},
+      FriendlyTargetHealth:{x:{anchor:0,px:-18},y:{anchor:1,px:195},locked:false,size:{width:350,height:200},scale:0.6},
+      Respawn:{x:{anchor:0,px:-100},y:{anchor:0,px:-100},locked:false,size:{width:200,height:200},scale:1},
     },
     version: MIN_STATE_VERSION_ANCHORED
   }
@@ -169,6 +164,7 @@ interface AnchoredAxis {
 interface AnchoredPosition {
   x: AnchoredAxis;
   y: AnchoredAxis;
+  locked: boolean;
   size: Size;
   scale: number;
 }
@@ -187,6 +183,7 @@ function position2anchor(current: Position, screen: Size) : AnchoredPosition {
   const position: AnchoredPosition = {
     x: axis2anchor(current.anchor.x, current.x, screen.width),
     y: axis2anchor(current.anchor.y, current.y, screen.height),
+    locked: current.anchor.locked,
     size: {
       width: current.width,
       height: current.height
@@ -211,7 +208,7 @@ function anchored2position(anchored: AnchoredPosition, screen: Size) : Position 
   const position = {
     x: anchor2axis(anchored.x, screen.width),
     y: anchor2axis(anchored.y, screen.height),
-    anchor: { x: anchored.x.anchor, y: anchored.y.anchor },
+    anchor: { x: anchored.x.anchor, y: anchored.y.anchor, locked: anchored.locked },
     width: anchored.size.width,
     height: anchored.size.height,
     scale: anchored.scale
@@ -240,8 +237,10 @@ function chooseAnchorForAxis(pos: number, extent: number, range: number) : AxisA
 
 function anchorPosition(current: Position, screen: Size) : Position {
   const anchored: Position = Object.assign({}, current);
-  anchored.anchor.x = chooseAnchorForAxis(anchored.x, anchored.width, screen.width);
-  anchored.anchor.y = chooseAnchorForAxis(anchored.y, anchored.height, screen.height);
+  if (!anchored.anchor.locked) {
+    anchored.anchor.x = chooseAnchorForAxis(anchored.x, anchored.width, screen.width);
+    anchored.anchor.y = chooseAnchorForAxis(anchored.y, anchored.height, screen.height);
+  }
   return anchored;
 }
 

--- a/game/hud/src/services/session/layout.ts
+++ b/game/hud/src/services/session/layout.ts
@@ -14,7 +14,6 @@ const SAY_SOMETHING = 'hud/layout/SAY_SOMETHING';
 
 const LOCK_HUD = 'hud/layout/LOCK_HUD';
 const UNLOCK_HUD = 'hud/layout/UNLOCK_HUD';
-const SET_POSITION = 'hud/layout/SET_POSITION';
 const SAVE_POSITION = 'hud/layout/SAVE_POSITION';
 const RESET_HUD = 'hud/layout/RESET_HUD';
 
@@ -76,14 +75,6 @@ export function resetHUD(): LayoutAction {
   return {
     type: RESET_HUD
   };
-}
-
-export function setPosition(name: string, pos: Position): LayoutAction {
-  return {
-    type: SET_POSITION,
-    widget: name,
-    position: pos
-  }
 }
 
 export function savePosition(name: string, pos: Position): LayoutAction {
@@ -343,13 +334,6 @@ export default function reducer(state: LayoutState = getInitialState(),
       outState = Object.assign({}, loadState(clone(initialState())));
       break;
     }
-    case SET_POSITION:
-      widgets = state.widgets;
-      widgets[action.widget] = action.position;
-      outState = Object.assign({}, state, {
-        widgets: widgets
-      });
-      break;
     case SAVE_POSITION:
       widgets = state.widgets;
       screen = { width: window.innerWidth, height: window.innerHeight };


### PR DESCRIPTION
https://trello.com/c/GWkZVZ6C

At the moment the UI widget movement logic auto-detects an anchor point.  An anchor point is the part of the screen the UI is positioned relative to, and is calculated per-axis as start, centre or end.  This gives us 9 anchor points on screen in total.   

    TL TC TR
    ML MC MR
    BL BC BR

This works quite well, but there are cases where this auto-anchoring doesn't quite do what you want it to do. 

I had an idea about having some kind of control in the red drag-able widget box that could be used to select an anchor point, locking the widget to that anchor point no matter where it is moved to on screen.

The idea has evolved into a working system, that works extremely well (I think) and solves another problem which I mentioned in chat a while back, and that is the ability to link separate UIs together, so they reposition as a single unit.

The design of this system in its current form is as follows, and is subject to a UX pass.

Each red box, has a set of 9 dots in a 3x3 centred grid.  Each dot is grey, with the one representing the current anchor position, in bright green (on).  Moving widgets about will change where the green dot appears depending on where the auto-anchor decided to anchor the widget.

Now, any of those 9 dots can be clicked with the mouse.  What this does is it locks the anchor point, preventing the auto-anchoring logic from changing the anchor point.  Locked anchors are represented as magenta dots.  Now you can anchor a widget to the bottom left and place it top right, and when the client window is resized, it will always maintain the same distance from the bottom right of the window.  Not a very useful example though.

If you want widgets to be anchored to left edge but near centre on a non-maximised client, then auto-anchoring will pick the centre to anchor to if positioning in the small window, but you can now override this by selecting centre left of centre right or for that matter centre top or centre bottom to anchor to, so that when the client window is maximised, the widgets go where you want them to.

Lastly, this issue of keeping widgets together is I think also solved by this solution, because essentially all widgets that share the same locked anchor, will always maintain the same distance from each other, so you can arrange widgets next to each other and anchor them all to the same point and they will always be kept together.

![Example of using anchors to keep widgets together](https://cdn.discordapp.com/attachments/198226794900488192/213437669026299914/unknown.png)