### PR TITLE
Use server/channel name as key, only get server population for the selected server

### DIFF
--- a/patcher/src/ts/redux/modules/channels.ts
+++ b/patcher/src/ts/redux/modules/channels.ts
@@ -12,7 +12,6 @@ const REQUEST_CHANNELS = 'cse-patcher/locations/REQUEST_CHANNELS';
 
 // sync actions
 export function changeChannel(channel: Channel): any {
-  const name = (channel) ? channel.channelID : "null";
   return {
     type: CHANGE_CHANNEL,
     channel: channel

--- a/patcher/src/ts/redux/modules/channels.ts
+++ b/patcher/src/ts/redux/modules/channels.ts
@@ -12,6 +12,7 @@ const REQUEST_CHANNELS = 'cse-patcher/locations/REQUEST_CHANNELS';
 
 // sync actions
 export function changeChannel(channel: Channel): any {
+  const name = (channel) ? channel.channelID : "null";
   return {
     type: CHANGE_CHANNEL,
     channel: channel

--- a/patcher/src/ts/sidebar/ServerSelect.tsx
+++ b/patcher/src/ts/sidebar/ServerSelect.tsx
@@ -43,7 +43,7 @@ export interface SelectServerState {
 
 class SelectServer extends React.Component<SelectServerProps, SelectServerState> {
 
-  private mergedServerList: {[key:string]: any } = {};
+  private mergedServerList: {[key:string]: any} = {};
   
   private listAsArray: any[] = null;
   

--- a/patcher/src/ts/sidebar/ServerSelect.tsx
+++ b/patcher/src/ts/sidebar/ServerSelect.tsx
@@ -7,7 +7,7 @@
 import * as React from 'react';
 import {connect} from 'react-redux';
 import {Channel, ChannelStatus, patcher} from '../api/patcherAPI';
-import {Server, AccessType} from '../redux/modules/servers';
+import {Server, AccessType, ServerPopulation} from '../redux/modules/servers';
 import * as events from '../../lib/events';
 
 import {changeChannel, requestChannels, ChannelState} from '../redux/modules/channels';
@@ -43,7 +43,7 @@ export interface SelectServerState {
 
 class SelectServer extends React.Component<SelectServerProps, SelectServerState> {
 
-  private mergedServerList: {[key:string]: any} = {};
+  private mergedServerList: {[key:string]: any } = {};
   
   private listAsArray: any[] = null;
   
@@ -80,16 +80,23 @@ class SelectServer extends React.Component<SelectServerProps, SelectServerState>
     dispatch(changeServer(server.serverInfo));
     if(server && server.shardID) this.trySelectCharacter(server.shardID);
     else dispatch(selectCharacter(null));
-    dispatch(fetchServers());
-    dispatch(requestChannels());
     this.setState({
       showList: false
     } as any);
   }
 
+  getTotalPopulation = (server:Server):ServerPopulation => {
+    if (!server || !server.channelID || !this.props.serversState || !this.props.serversState.serverPopulations) return { serverName: '', arthurians: 0, vikings: 0, tuathaDeDanann: 0};; 
+    
+    const serverPop = this.props.serversState.serverPopulations[server.name];
+    if (serverPop) return serverPop;
+    
+    return { serverName: '', arthurians: 0, vikings: 0, tuathaDeDanann: 0};; 
+  } 
+
   renderItem(item: any, hideSelected:boolean) {
-    if (item.serverInfo && !(hideSelected && this.props.serversState.currentServer && this.props.serversState.currentServer.channelID == item.serverInfo.channelID)) {
-      const totalPlayers = (item.serverInfo.arthurians|0) + (item.serverInfo.tuathaDeDanann|0) + (item.serverInfo.vikings|0);
+    if (item.serverInfo && !(hideSelected && this.props.serversState.currentServer && this.props.serversState.currentServer.name == item.serverInfo.name)) {
+      const totalPlayers = this.getTotalPopulation(this.props.serversState.currentServer); //BUG: displaying the current server pop for every server in the list
       const status = item.serverInfo.playerMaximum > 0 ? 'online' : 'offline';
       const accessLevel = AccessType[item.serverInfo.accessLevel];
 
@@ -97,13 +104,13 @@ class SelectServer extends React.Component<SelectServerProps, SelectServerState>
         <div className='server-select' onClick={() => this.onSelectedServerChanged(item)}>
           <div className='server-details'>
             <h5 className='server'>{item.displayName} ({accessLevel})</h5>
-            <h6 className='server-players'>Players Online: {totalPlayers}/{item.serverInfo.playerMaximum}</h6>
+            <h6 className='server-players'>Players Online: {totalPlayers.arthurians + totalPlayers.tuathaDeDanann + totalPlayers.vikings}/{item.serverInfo.playerMaximum}</h6>
           </div>
           <div className='server-status'><div className={'indicator ' + status} data-position='right'
             data-delay='150' data-tooltip={status} /></div>
         </div>
       );
-    } else if(!(hideSelected && this.props.channelsState.selectedChannel && this.props.channelsState.selectedChannel.channelID == item.channelInfo.channelID)) {
+    } else if(!(hideSelected && this.props.channelsState.selectedChannel && this.props.channelsState.selectedChannel.channelName == item.channelInfo.channelName)) {
       return (
         <div className='server-select' onClick={() => this.onSelectedServerChanged(item)}>
           <div className='server-details'>
@@ -114,20 +121,36 @@ class SelectServer extends React.Component<SelectServerProps, SelectServerState>
     }    
   }
 
+  //TODO: take care of this at the store level
   mergeServerChannelLists(servers:Array<Server>, channels:Array<Channel>) : any {
 
     let filteredServers:Array<Server> = servers.filter((s) => { return s.name != 'localhost'; });
 
     filteredServers.forEach(s => {
-      this.mergedServerList[s.channelID] = this.mergedServerList[s.channelID] || { displayName: s.name, serverInfo: null, channelInfo:null };
-      this.mergedServerList[s.channelID].serverInfo = s;
-      this.mergedServerList[s.channelID].displayName = s.name;
+      this.mergedServerList[s.name] = this.mergedServerList[s.name] || { displayName: s.name, serverInfo: null, channelInfo:null };
+      this.mergedServerList[s.name].serverInfo = s;
+      this.mergedServerList[s.name].displayName = s.name;
     });
 
     channels.forEach(c => {
-      this.mergedServerList[c.channelID] = this.mergedServerList[c.channelID] || { displayName: c.channelName, serverInfo: null, channelInfo:null };
-      this.mergedServerList[c.channelID].channelInfo = c;
-      this.mergedServerList[c.channelID].displayName = c.channelName;
+      let channelFound = false;
+      for (var key in this.mergedServerList) {
+          let channelId =  -1
+          
+          if (this.mergedServerList[key].serverInfo && this.mergedServerList[key].serverInfo.channelID) channelId = this.mergedServerList[key].serverInfo.channelID;
+          else if (this.mergedServerList[key].channelInfo && this.mergedServerList[key].channelInfo.channelID) channelId = this.mergedServerList[key].channelInfo.channelID;
+          
+          if (channelId === c.channelID) {
+            channelFound = true;
+            this.mergedServerList[key].channelInfo = c;
+          }
+      }
+
+      if(!channelFound) {
+        this.mergedServerList[c.channelName] = this.mergedServerList[c.channelName] || { displayName: c.channelName, serverInfo: null, channelInfo:null };
+        this.mergedServerList[c.channelName].channelInfo = c;
+        this.mergedServerList[c.channelName].displayName = c.channelName;
+      }
     });
 
     let dictToArray:any[] = [];
@@ -141,8 +164,8 @@ class SelectServer extends React.Component<SelectServerProps, SelectServerState>
     if (!currentServer && !selectedChannel) return 0;
 
     return this.listAsArray.indexOf(this.listAsArray.find((i: any) => {
-      if (i.serverInfo && currentServer) return i.serverInfo.channelID == currentServer.channelID;
-      else if (i.channelInfo && selectedChannel) return i.channelInfo.channelID == selectedChannel.channelID;
+      if (i.serverInfo && currentServer) return i.serverInfo.name == currentServer.name;
+      else if (i.channelInfo && selectedChannel) return i.channelInfo.channelName == selectedChannel.channelName;
       return false;
     }));
   }

--- a/patcher/src/ts/sidebar/Sidebar.tsx
+++ b/patcher/src/ts/sidebar/Sidebar.tsx
@@ -32,7 +32,7 @@ import {fetchAlerts, validateAlerts, PatcherAlertsState} from '../redux/modules/
 import {changeChannel, requestChannels, ChannelState} from '../redux/modules/channels';
 import {muteSounds, unMuteSounds} from '../redux/modules/sounds';
 import {muteMusic, unMuteMusic} from '../redux/modules/music';
-import {fetchServers, changeServer, ServersState} from '../redux/modules/servers';
+import {fetchServers, changeServer, ServersState, fetchServerPopulation, ServerPopulation} from '../redux/modules/servers';
 import {fetchCharacters, selectCharacter, characterCreated, CharactersState} from '../redux/modules/characters';
 
 const lastPlay: any = JSON.parse(localStorage.getItem('cse-patcher-lastplay'));
@@ -44,7 +44,7 @@ function select(state: any): any {
     soundMuted: state.soundMuted,
     musicMuted: state.musicMuted,
     serversState: state.servers,
-    charactersState: state.characters,
+    charactersState: state.characters
   }
 }
 
@@ -72,6 +72,7 @@ class Sidebar extends React.Component<SidebarProps, SidebarState> {
   private alertsInterval: any = null;
   private channelsInterval: any = null;
   private serversInterval: any = null;
+  private serverPopInterval: any = null;
 
   static propTypes = {
     alerts: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
@@ -87,18 +88,32 @@ class Sidebar extends React.Component<SidebarProps, SidebarState> {
     };
   }
 
+  getInitialServer = ():Server => {
+    if (!this.props.serversState || !this.props.serversState.servers || this.props.serversState.servers.length === 0 ) return null; //no server to select
+
+    const lastServer = lastPlay && lastPlay.serverName ? lastPlay.serverName : null;
+    if (lastServer) {
+      const lServer =  this.props.serversState.servers.find(s => s.name === lastServer);
+      if(lServer) return lServer;
+    }
+
+    return this.props.serversState.servers[0]; //couldn't find the last server, default to the top one in the list
+  }
+
   onLogIn = () => {
     const {onLogIn, dispatch} = this.props;
 
     const lastCharacterID = lastPlay && lastPlay.characterID ? lastPlay.characterID : null;
-    const lastServer = lastPlay && lastPlay.serverName ? lastPlay.serverName : null;
+    //const lastServer = lastPlay && lastPlay.serverName ? lastPlay.serverName : null;
     const lastChannel = lastPlay && lastPlay.channelID ? lastPlay.channelID : null;
 
     onLogIn();
     dispatch(requestChannels(lastChannel));
-    dispatch(fetchServers(lastServer));
+    //dispatch(fetchServers(lastServer));
+    const initialServer = this.getInitialServer();
+    console.log('inital server: ' + JSON.stringify(initialServer));
+    dispatch(changeServer(initialServer));
     this.fetchCharacters();
-    this.scheduleUpdateServerStatus();
   }
 
   onLogOut = () => {
@@ -222,6 +237,11 @@ class Sidebar extends React.Component<SidebarProps, SidebarState> {
     if (!this.props.serversState.isFetching) dispatch(fetchServers());
     this.serversInterval = setInterval(() => {
       if (!this.props.serversState.isFetching) dispatch(fetchServers()); 
+    }, 60000);
+
+    dispatch(requestChannels());
+    this.serverPopInterval = setInterval(() => {
+      if (this.props.serversState.currentServer) dispatch(fetchServerPopulation(this.props.serversState.currentServer));
     }, 30000);
   }
 
@@ -230,14 +250,15 @@ class Sidebar extends React.Component<SidebarProps, SidebarState> {
     clearInterval(this.alertsInterval);
     clearInterval(this.channelsInterval);
     clearInterval(this.serversInterval);
+    clearInterval(this.serverPopInterval);
   }
-
-  scheduleUpdateServerStatus = () => {
-    const {dispatch} = this.props;
-    setTimeout(() => {
-      dispatch(requestChannels());
-      dispatch(fetchServers());
-    }, 500);
+  
+  getServerPops = ():ServerPopulation => {
+    if (!this.props.serversState || !this.props.serversState.currentServer) return { serverName: '', arthurians: 0, vikings: 0, tuathaDeDanann: 0}; 
+    
+    const serverPop = this.props.serversState.serverPopulations[this.props.serversState.currentServer.name];
+    if (serverPop) return serverPop;
+    else return { serverName: '', arthurians: 0, vikings: 0, tuathaDeDanann: 0}; 
   }
 
   render() {
@@ -254,14 +275,16 @@ class Sidebar extends React.Component<SidebarProps, SidebarState> {
 
     if (this.props.serversState.currentServer) {
       //todo: redux up ServerCounts, componentize character buttons
+      const serverPop = this.getServerPops();
+
       renderServerSection = (
         <div>
           <ServerSelect/>
           <CharacterSelect/>
           { this.generateCharacterButtons(this.props.serversState.currentServer.shardID, this.props.charactersState.selectedCharacter) }
-          <ServerCounts artCount={this.props.serversState.currentServer.arthurians}
-                        tddCount={this.props.serversState.currentServer.tuathaDeDanann}
-                        vikCount={this.props.serversState.currentServer.vikings} />
+          <ServerCounts artCount={serverPop.arthurians}
+                        tddCount={serverPop.tuathaDeDanann}
+                        vikCount={serverPop.vikings} />
         </div>
       );
     } else {

--- a/patcher/src/ts/sidebar/Sidebar.tsx
+++ b/patcher/src/ts/sidebar/Sidebar.tsx
@@ -104,12 +104,10 @@ class Sidebar extends React.Component<SidebarProps, SidebarState> {
     const {onLogIn, dispatch} = this.props;
 
     const lastCharacterID = lastPlay && lastPlay.characterID ? lastPlay.characterID : null;
-    //const lastServer = lastPlay && lastPlay.serverName ? lastPlay.serverName : null;
     const lastChannel = lastPlay && lastPlay.channelID ? lastPlay.channelID : null;
 
     onLogIn();
     dispatch(requestChannels(lastChannel));
-    //dispatch(fetchServers(lastServer));
     const initialServer = this.getInitialServer();
     console.log('inital server: ' + JSON.stringify(initialServer));
     dispatch(changeServer(initialServer));


### PR DESCRIPTION
- Channel id is not a suitable key for the server list
- Decouple getting the server population from the server list, only poll the server population for the currently selected server, poll servers much less frequently

Using the channel id as the key turned out to be very broken, using the name as the key now.
