### PR TITLE
Add resilience when loading hud state

### DIFF
--- a/game/hud/src/services/session/layout.ts
+++ b/game/hud/src/services/session/layout.ts
@@ -272,8 +272,19 @@ function getInitialState(): any {
   return loadState(initialState());
 }
 
-function loadState(state: LayoutState = JSON.parse(localStorage.getItem(localStorageKey)) as LayoutState) : LayoutState {
+function loadStateFromStorage(): LayoutState {
+  let state: string;
+  try {
+    state = localStorage.getItem(localStorageKey);
+    return JSON.parse(state);
+  } catch(e) {
+    const error: Error = e;
+    console.error('loadStateFromStorage: ' + error.message + ' state=' + state);
+    return null;
+  }
+}
 
+function loadState(state: LayoutState = loadStateFromStorage()) : LayoutState {
   if (state) {
     const reset = state.reset !== FORCE_RESET_CODE;
     if (!reset) {


### PR DESCRIPTION
Loading state currently just calls JSON.parse() but that will throw an exception if the JSON is invalid.  This change adds a wrapper to that call, that will return null if the settings are corrupt which will lead to default settings being loaded.  Details of the error are written to the console including the corrupt JSON string.