### PR TITLE
Show logo video once before cycling through API results.

### DIFF
--- a/patcher/src/components/Hero/index.tsx
+++ b/patcher/src/components/Hero/index.tsx
@@ -22,18 +22,30 @@ export interface HeroProps {
 
 export interface HeroState {
   currentItem: number;
+  firstLoad: boolean;
 }
 
 class Hero extends React.Component<HeroProps, HeroState> {
   public name:string = 'cse-patcher-hero';
   private timeout: any = null;
-    
+
   constructor(props: HeroProps) {
     super(props);
-    this.state = {currentItem: 0};
-    this.timeNext(1);
+    this.state = {currentItem: -1, firstLoad: true};
+    setTimeout(() => {
+      this.setState({currentItem: 0, firstLoad: false});
+      this.timeNext(1);
+    }, 10000);
   }
-  
+
+  renderLogo = () => {
+    return (
+      <div className='cse-patcher-hero-item' key='logoKey1'>
+        <div dangerouslySetInnerHTML={{__html: `<style> .logo-reveal-vid {position: fixed;top: 50%;left: 50%;min-width: 100%;min-height: 100%;width: auto;height: auto;transform: translateX(-50%) translateY(-50%);background-size: cover;}</style><video class='logo-reveal-vid' src='./videos/logo-reveal.webm' autoplay></video>`}}></div>
+      </div>
+    )
+  }
+
   renderHeroItem = (item: HeroContentItem) => {
     return (
       <div className='cse-patcher-hero-item' key={item.id}>
@@ -41,28 +53,29 @@ class Hero extends React.Component<HeroProps, HeroState> {
       </div>
     )
   }
-  
+
   selectIndex = (index: number) => {
     clearTimeout(this.timeout);
     this.timeout = null;
     this.setState({
-      currentItem: index
+      currentItem: index,
+      firstLoad: false
     });
     this.timeNext(index++);
   }
-  
+
   timeNext = (index: number) => {
     let next = this.state.currentItem+1;
     if (next >= this.props.items.length) next = 0;
     this.timeout = setTimeout(() => this.selectIndex(next), 30000);
   }
-  
+
   componentWillUnmount() {
     clearInterval(this.timeout);
   }
 
   render() {
-    var currentItem = this.props.items.length > 0 ? this.renderHeroItem(this.props.items[this.state.currentItem]) : null;
+    const currentItem = this.state.firstLoad ? this.renderLogo() : this.props.items.length > 0 ? this.renderHeroItem(this.props.items[this.state.currentItem]) : null;
     return (
       <div id={this.name} className='main-content'>
         <Animate animationEnter='fadeIn' animationLeave='fadeOut'

--- a/patcher/src/services/session/heroContent.ts
+++ b/patcher/src/services/session/heroContent.ts
@@ -67,7 +67,14 @@ export function fetchHeroContent() {
   return (dispatch: (action: any) => any) => {
     dispatch(requestHeroContent());
     return fetchJSON(HeroContentUrl)
-      .then((items: HeroContentItem[]) => dispatch(fetchHeroContentSuccess(items)))
+      .then((items: HeroContentItem[]) => {
+        items.sort(function(a, b) {
+          const aDate = new Date(a.utcDateStart);
+          const bDate = new Date(b.utcDateStart);
+          return aDate > bDate ? -1 : aDate < bDate ? 1 : 0;
+        });
+        dispatch(fetchHeroContentSuccess(items))
+      })
       .catch((error: ResponseError) => dispatch(fetchHeroContentFailed(error)));
   }
 }


### PR DESCRIPTION
Although JB explained that the upcoming patcher redesign makes this unnecessary, I played around with it anyway. This now does what my old PR did, but without breaking the auto-cycling of the videos pulled from the API server:

1. On first load, the locally saved logo video will play once.
2. After the logo video is shown once, all videos from the API will begin cycling as they always did.

The logo video can then be removed from the patcher API and everything will look great. We'll get to see the awesome logo video once, but it won't look awkward when it loops several times.

Feel free to reject the PR again. I just did this for fun, but do think it's an improvement to the current behavior.