### PR TITLE
Don't display scroll bar for quick select items that don't need them

### DIFF
--- a/patcher/src/components/QuickSelect/index.tsx
+++ b/patcher/src/components/QuickSelect/index.tsx
@@ -23,6 +23,7 @@ export interface QuickSelectProps {
   selectedItemIndex?: any;
   activeViewComponentGenerator: (item: any) => any;
   listViewComponentGenerator: (item: any) => any;
+  itemHeight: number;
   onSelectedItemChanged: (item: any) => void;
   containerClass?: string;
   showActiveInList?: boolean;
@@ -96,7 +97,8 @@ class QuickSelect extends React.Component<QuickSelectProps, QuickSelectState> {
             this.showList(!this.state.showList);
             e.stopPropagation();
           }} ><i className={`fa ${this.state.showList ? 'fa-chevron-down' : 'fa-chevron-up'}`} aria-hidden="true"></i></div>
-        <div className={`QuickSelect__listView ${this.state.showList ? '' : 'QuickSelect__listView--hidden'}`} >
+        <div className={`QuickSelect__listView ${this.state.showList ? '' : 'QuickSelect__listView--hidden'}`}
+             style={this.props.items.length > ((420/this.props.itemHeight)|0) ? {} : {overflow: 'hidden'}} >
           {this.props.items.map(this.buildListItem)}
         </div>
       </div>

--- a/patcher/src/components/QuickSelect/index.tsx
+++ b/patcher/src/components/QuickSelect/index.tsx
@@ -98,7 +98,7 @@ class QuickSelect extends React.Component<QuickSelectProps, QuickSelectState> {
             e.stopPropagation();
           }} ><i className={`fa ${this.state.showList ? 'fa-chevron-down' : 'fa-chevron-up'}`} aria-hidden="true"></i></div>
         <div className={`QuickSelect__listView ${this.state.showList ? '' : 'QuickSelect__listView--hidden'}`}
-             style={this.props.items.length > ((420/this.props.itemHeight)|0) ? {} : {overflow: 'hidden'}} >
+             style={this.props.items.length > ((420/(this.props.itemHeight+1))|0) ? {} : {overflow: 'hidden'}} >
           {this.props.items.map(this.buildListItem)}
         </div>
       </div>

--- a/patcher/src/widgets/Controller/components/CharacterSelect/index.scss
+++ b/patcher/src/widgets/Controller/components/CharacterSelect/index.scss
@@ -30,6 +30,7 @@ $colorV: #124d66;//border color
 
 .ActiveCharacterView {
   display: flex;
+  height: 66px;
   justify-content: space-between;
   user-select: none;
   -webkit-user-select: none;

--- a/patcher/src/widgets/Controller/components/CharacterSelect/index.tsx
+++ b/patcher/src/widgets/Controller/components/CharacterSelect/index.tsx
@@ -164,7 +164,7 @@ class CharacterSelect extends React.Component<CharacterSelectProps, CharacterSel
                             </div>
                           )}
                         listViewComponentGenerator={c => null}
-                        itemHeight={67}
+                        itemHeight={66}
                         onSelectedItemChanged={() => null} />
       );
     }
@@ -196,7 +196,7 @@ class CharacterSelect extends React.Component<CharacterSelectProps, CharacterSel
                         selectedItemIndex={utils.findIndexWhere(serverCharacters, c => c.id === selectedCharacter.id)}
                         activeViewComponentGenerator={c => <ActiveCharacterView character={c} />}
                         listViewComponentGenerator={c => <CharacterListView character={c} />}
-                        itemHeight={67}
+                        itemHeight={66}
                         onSelectedItemChanged={this.selectCharacter} />;
   }
 }

--- a/patcher/src/widgets/Controller/components/CharacterSelect/index.tsx
+++ b/patcher/src/widgets/Controller/components/CharacterSelect/index.tsx
@@ -149,7 +149,7 @@ class CharacterSelect extends React.Component<CharacterSelectProps, CharacterSel
 
     let serverCharacters: webAPI.characters.SimpleCharacter[] = [];
     for (const key in characters) {
-      if (characters[key].shardID === selectedServer.shardID) serverCharacters.push(characters[key]); 
+      if (characters[key].shardID === selectedServer.shardID) serverCharacters.push(characters[key]);
     }
 
     if (serverCharacters.length == 0) {
@@ -164,6 +164,7 @@ class CharacterSelect extends React.Component<CharacterSelectProps, CharacterSel
                             </div>
                           )}
                         listViewComponentGenerator={c => null}
+                        itemHeight={67}
                         onSelectedItemChanged={() => null} />
       );
     }
@@ -195,6 +196,7 @@ class CharacterSelect extends React.Component<CharacterSelectProps, CharacterSel
                         selectedItemIndex={utils.findIndexWhere(serverCharacters, c => c.id === selectedCharacter.id)}
                         activeViewComponentGenerator={c => <ActiveCharacterView character={c} />}
                         listViewComponentGenerator={c => <CharacterListView character={c} />}
+                        itemHeight={67}
                         onSelectedItemChanged={this.selectCharacter} />;
   }
 }

--- a/patcher/src/widgets/Controller/components/GameSelect/index.scss
+++ b/patcher/src/widgets/Controller/components/GameSelect/index.scss
@@ -18,5 +18,5 @@
 
 .ActiveGameView {
   padding: 10px;
-  height: 49px;
+  height: 29px;
 }

--- a/patcher/src/widgets/Controller/components/GameSelect/index.scss
+++ b/patcher/src/widgets/Controller/components/GameSelect/index.scss
@@ -18,4 +18,5 @@
 
 .ActiveGameView {
   padding: 10px;
+  height: 49px;
 }

--- a/patcher/src/widgets/Controller/components/GameSelect/index.tsx
+++ b/patcher/src/widgets/Controller/components/GameSelect/index.tsx
@@ -68,7 +68,7 @@ class GameSelect extends React.Component<GameSelectProps, GameSelectState> {
                         selectedItemIndex={utils.findIndexWhere(values, t => t === selectedType)}
                         activeViewComponentGenerator={t => <ActiveGameView type={t} />}
                         listViewComponentGenerator={t => <GameListView type={t}/>}
-                        itemHeight={50}
+                        itemHeight={49}
                         onSelectedItemChanged={this.selectType} />;
   }
 }

--- a/patcher/src/widgets/Controller/components/GameSelect/index.tsx
+++ b/patcher/src/widgets/Controller/components/GameSelect/index.tsx
@@ -68,6 +68,7 @@ class GameSelect extends React.Component<GameSelectProps, GameSelectState> {
                         selectedItemIndex={utils.findIndexWhere(values, t => t === selectedType)}
                         activeViewComponentGenerator={t => <ActiveGameView type={t} />}
                         listViewComponentGenerator={t => <GameListView type={t}/>}
+                        itemHeight={50}
                         onSelectedItemChanged={this.selectType} />;
   }
 }

--- a/patcher/src/widgets/Controller/components/ServerSelect/index.scss
+++ b/patcher/src/widgets/Controller/components/ServerSelect/index.scss
@@ -18,6 +18,7 @@
 
 .ActiveServerView {
   display: flex;
+  height: 67px;
 }
 
 .ActiveServerView__access {
@@ -36,7 +37,7 @@
 
 .ActiveServerView__status {
   padding: 5px 0 5px 5px;
-  
+
   .online {
     color: #5a8110;
   }

--- a/patcher/src/widgets/Controller/components/ServerSelect/index.tsx
+++ b/patcher/src/widgets/Controller/components/ServerSelect/index.tsx
@@ -153,7 +153,7 @@ class ServerSelect extends React.Component<ServerSelectProps, ServerSelectState>
                         selectedItemIndex={utils.findIndexWhere(values, s => s.name === selectedServer.name)}
                         activeViewComponentGenerator={s => <ActiveServerView server={s} />}
                         listViewComponentGenerator={s => <ServerListView server={s} />}
-                        itemHeight={68}
+                        itemHeight={67}
                         onSelectedItemChanged={this.selectServer} />;
   }
 }

--- a/patcher/src/widgets/Controller/components/ServerSelect/index.tsx
+++ b/patcher/src/widgets/Controller/components/ServerSelect/index.tsx
@@ -16,7 +16,7 @@ class ActiveServerView extends React.Component<{server: PatcherServer}, {}> {
   render() {
     const {server} = this.props;
     switch(server.type) {
-      
+
       default:
         return (
           <div className='ActiveServerView'>
@@ -47,7 +47,7 @@ class ServerListView extends React.Component<{server: PatcherServer}, {}> {
   render() {
     const {server} = this.props;
     switch(server.type) {
-      
+
       default:
         return (
           <div className='ActiveServerView'>
@@ -153,6 +153,7 @@ class ServerSelect extends React.Component<ServerSelectProps, ServerSelectState>
                         selectedItemIndex={utils.findIndexWhere(values, s => s.name === selectedServer.name)}
                         activeViewComponentGenerator={s => <ActiveServerView server={s} />}
                         listViewComponentGenerator={s => <ServerListView server={s} />}
+                        itemHeight={68}
                         onSelectedItemChanged={this.selectServer} />;
   }
 }


### PR DESCRIPTION
This is not a complete fix, there are two main issues with it:

* The itemHeight is hard coded
* There is some kind of delay when no longer needing scroll bars before UI properly updates.  This can be seen if you have 7 characters and delete one, then immediately open up the character list, there is space left for a scroll bar, that disappears after a few seconds.

The change adds itemHeight={n} property to QuickSelect, which QuickSelect uses to predict if a scroll bar will be required to display the supplied number of items.  If no scroll bar is required, overflow: hidden is added to the popup.  This prevents the scrollbar appearing while the popup list is transitioning into view if the resulting list will not show a scrollbar.  Giving a much nicer animation.

https://dl.dropboxusercontent.com/u/43876768/QuickSelect4.gif
