### PR TITLE
Change cursor for QuickSelect activeView to a pointer.

### DIFF
--- a/patcher/src/components/QuickSelect/index.scss
+++ b/patcher/src/components/QuickSelect/index.scss
@@ -42,6 +42,7 @@
   overflow: hidden;
   display: flex;
   align-items: center;
+  cursor: pointer;
 }
 
 .QuickSelect__listView {


### PR DESCRIPTION
Change cursor for QuickSelect activeView to a pointer, to indicate that it can be used to open the list.  It also prevents the text cursor appearing when moving over the text.