### PR TITLE
Use WebkitClipPath rather than -webkit-clip-path for style property

### DIFF
--- a/game/hud/src/components/PlayerStatusComponent/components/Pills/index.tsx
+++ b/game/hud/src/components/PlayerStatusComponent/components/Pills/index.tsx
@@ -242,7 +242,7 @@ class Pills extends React.Component<PillsProps, PillsState> {
     }
 
     // build clip path for pills
-    const clipPath: any = { '-webkit-clip-path': this.clipPathForPills(pill) };
+    const clipPath: any = { 'WebkitClipPath': this.clipPathForPills(pill) };
 
     let dimension = orientation === Orientation.Horizontal ? 'width' : 'height';
 


### PR DESCRIPTION
React is complaining about the use of ```-webkit-clip-path``` as a style property name and suggested using ```WebkitClipPath``` instead, so I have!