### PR TITLE
Fix position of patch progress percentage

### DIFF
--- a/patcher/src/widgets/Controller/components/ProgressBar/index.scss
+++ b/patcher/src/widgets/Controller/components/ProgressBar/index.scss
@@ -15,8 +15,10 @@
   margin: -7px -5px 2px -5px;
   label {
     color: #8f8f8f;
-    margin: 0px 5px;
+    margin: 3px 5px;
     font-size: 0.8em;
+    position: absolute;
+    right: 0;
   }
 }
 


### PR DESCRIPTION
It's annoyed me ever since the new layout patcher was introduced :)  Position the progress % counter just below the end of the progress bar instead of shrinking the progress bar to make it fit to the right.

Old Layout
![Old](https://dl.dropboxusercontent.com/u/43876768/patcher-pcnt-old.png)

New Layout
![New](https://dl.dropboxusercontent.com/u/43876768/patcher-pcnt-new.png)