### PR TITLE
Cu order browser

### DIFF
--- a/game/hud/package.json
+++ b/game/hud/package.json
@@ -101,7 +101,7 @@
     "node-sass": "^3.8.0",
     "p-s": "^3.1.0",
     "tslint": "^4.4.2",
-    "typescript": "^2.1.6",
+    "typescript": "2.1.6",
     "typings": "^1.3.2",
     "watch-cli": "^0.2.1"
   }

--- a/game/hud/src/widgets/Social/components/GridViewPager.tsx
+++ b/game/hud/src/widgets/Social/components/GridViewPager.tsx
@@ -3,10 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * @Author: JB (jb@codecorsair.com)
- * @Date: 2017-01-30 14:52:18
- * @Last Modified by: JB (jb@codecorsair.com)
- * @Last Modified time: 2017-02-27 11:49:08
+ * @Author: Mehuge (mehuge@sorcerer.co.uk)
+ * @Date: 2017-03-08
  */
 
 import * as React from 'react';

--- a/game/hud/src/widgets/Social/components/GridViewPager.tsx
+++ b/game/hud/src/widgets/Social/components/GridViewPager.tsx
@@ -10,12 +10,14 @@
  */
 
 import * as React from 'react';
-import { GridViewImpl, GridViewProps, GridViewState } from 'camelot-unchained';
+import { GridViewImpl, GridViewProps, GridViewState, GridViewSort, ColumnDefinition, SortInfo } from 'camelot-unchained';
+import { clone } from 'lodash';
 
 export interface GridViewPagerProps extends GridViewProps {
   total: number;
   currentPage: number;
   gotoPage: (page: number) => void;
+  onSort: (index: number, asc: boolean) => void;
 }
 
 export interface GridViewPagerState extends GridViewState {
@@ -30,5 +32,12 @@ export default class GridViewPager extends GridViewImpl<GridViewPagerProps, Grid
   }
   goToPage = (page: number) => {
     this.props.gotoPage(page);
+  }
+  setSort = (index: number, sortBy: GridViewSort) => {
+    this.props.onSort(index, sortBy == GridViewSort.Up);
+    this.setState({ currentSort: { index: index, sorted: sortBy } });
+  }
+  sortItems = (input: any[], column: ColumnDefinition, sorted: GridViewSort) => {
+    return input;
   }
 }

--- a/game/hud/src/widgets/Social/components/GridViewPager.tsx
+++ b/game/hud/src/widgets/Social/components/GridViewPager.tsx
@@ -1,0 +1,34 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * @Author: JB (jb@codecorsair.com)
+ * @Date: 2017-01-30 14:52:18
+ * @Last Modified by: JB (jb@codecorsair.com)
+ * @Last Modified time: 2017-02-27 11:49:08
+ */
+
+import * as React from 'react';
+import { GridViewImpl, GridViewProps, GridViewState } from 'camelot-unchained';
+
+export interface GridViewPagerProps extends GridViewProps {
+  total: number;
+  currentPage: number;
+  gotoPage: (page: number) => void;
+}
+
+export interface GridViewPagerState extends GridViewState {
+}
+
+export default class GridViewPager extends GridViewImpl<GridViewPagerProps, GridViewPagerState> {
+  getItemCount = () : number => {
+    return this.props.total;
+  }
+  getCurrentPage = () => {
+    return this.props.currentPage;
+  }
+  goToPage = (page: number) => {
+    this.props.gotoPage(page);
+  }
+}

--- a/game/hud/src/widgets/Social/components/OrderContent.tsx
+++ b/game/hud/src/widgets/Social/components/OrderContent.tsx
@@ -3,8 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * @Author: Mehuge (mehuge@sorcerer.co.uk)
- * @Date: 2017-03-08
+ * @Author: JB (jb@codecorsair.com)
+ * @Date: 2017-01-25 18:09:02
+ * @Last Modified by: Mehuge (mehuge@sorcerer.co.uk)
+ * @Last Modified time: 2017-03-08
  */
 
 import * as React from 'react';

--- a/game/hud/src/widgets/Social/components/OrderContent.tsx
+++ b/game/hud/src/widgets/Social/components/OrderContent.tsx
@@ -19,6 +19,7 @@ import RankList from './RankList';
 import MemberList from './MemberList';
 import CreateGroup from './CreateGroup';
 import OrderAdmin from './OrderAdmin';
+import OrdersList from './OrdersList';
 
 export interface OrderContentProps {
   dispatch: (action: any) => any;
@@ -54,10 +55,10 @@ export class OrderContent extends React.Component<OrderContentProps, OrderConten
 
     if (!props.order) {
       switch (props.address.id) {
-        case 'create': 
-        case 'list': 
+        case 'create':
+        case 'list':
           break;
-        default: 
+        default:
           if (!props.order) {
             props.dispatch(selectLink({
               kind: 'Primary',
@@ -99,10 +100,12 @@ export class OrderContent extends React.Component<OrderContentProps, OrderConten
                       group={this.props.order}
                       userPermissions={this.props.order.myMemberInfo.permissions}
                       refetch={this.props.refetch} />
-      case 'admin': 
+      case 'admin':
         return <OrderAdmin dispatch={this.props.dispatch}
                            order={this.props.order}
                            refetch={this.props.refetch} />
+      case 'list':
+        return <OrdersList refetch={this.props.refetch} />;
       default:
         return <div>NO CONTENT</div>;
     }

--- a/game/hud/src/widgets/Social/components/OrderContent.tsx
+++ b/game/hud/src/widgets/Social/components/OrderContent.tsx
@@ -3,10 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * @Author: JB (jb@codecorsair.com)
- * @Date: 2017-01-25 18:09:02
- * @Last Modified by: JB (jb@codecorsair.com)
- * @Last Modified time: 2017-02-27 12:44:04
+ * @Author: Mehuge (mehuge@sorcerer.co.uk)
+ * @Date: 2017-03-08
  */
 
 import * as React from 'react';

--- a/game/hud/src/widgets/Social/components/OrderContent.tsx
+++ b/game/hud/src/widgets/Social/components/OrderContent.tsx
@@ -78,7 +78,7 @@ export class OrderContent extends React.Component<OrderContentProps, OrderConten
                             refetch={this.props.refetch}
                             dispatch={this.props.dispatch} />;
       case 'list':
-        // todo
+        return <OrdersList refetch={this.props.refetch} />;
     }
 
     if (!this.props.order) {
@@ -104,8 +104,6 @@ export class OrderContent extends React.Component<OrderContentProps, OrderConten
         return <OrderAdmin dispatch={this.props.dispatch}
                            order={this.props.order}
                            refetch={this.props.refetch} />
-      case 'list':
-        return <OrdersList refetch={this.props.refetch} />;
       default:
         return <div>NO CONTENT</div>;
     }

--- a/game/hud/src/widgets/Social/components/OrdersGrid.tsx
+++ b/game/hud/src/widgets/Social/components/OrdersGrid.tsx
@@ -34,6 +34,9 @@ export interface OrdersGridQuery {
     data: {
       id: string;
       name: string;
+      realm: string;
+      created: string;
+      creator: string;
     }[]
   }
 }
@@ -50,18 +53,6 @@ export interface OrdersGridProps extends InjectedGraphQLProps<OrdersGridQuery> {
   reverse: boolean;
   orderBy: (by: string, asc: boolean) => void;
 };
-
-function stricmp(a: string, b: string) {
-  a = a.toLowerCase();
-  b = b.toLowerCase();
-  return a < b ? -1 : b > a ? 1 : 0;
-}
-
-function datecmp(a: string, b: string) {
-  const da = new Date(a);
-  const db = new Date(b);
-  return da < db ? -1 : da > db ? 1 : 0;
-}
 
 interface OrdersListColumn extends ColumnDefinition {
   sortField?: string;

--- a/game/hud/src/widgets/Social/components/OrdersGrid.tsx
+++ b/game/hud/src/widgets/Social/components/OrdersGrid.tsx
@@ -3,10 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * @Author: JB (jb@codecorsair.com)
- * @Date: 2017-01-30 14:52:18
- * @Last Modified by: JB (jb@codecorsair.com)
- * @Last Modified time: 2017-02-27 11:49:08
+ * @Author: Mehuge (mehuge@sorcerer.co.uk)
+ * @Date: 2017-03-08
  */
 
 import * as React from 'react';
@@ -146,14 +144,14 @@ const query = gql`
 `;
 
 const options = (props: OrdersGridProps) => {
-  var opts = {
+  const opts = {
     variables: {
       filter: props.filter||"",
       shard: props.shard|0,
       skip: props.skip|0,
       count: props.itemsPerPage|0,
       sort: props.sort||"",
-      reverse: props.reverse||false
+      reverse: props.reverse||false,
     }
   }
   return opts;
@@ -161,4 +159,3 @@ const options = (props: OrdersGridProps) => {
 
 const OrdersGridWithQL = graphql(query, { options: options })(OrdersGrid);
 export default OrdersGridWithQL;
-

--- a/game/hud/src/widgets/Social/components/OrdersGrid.tsx
+++ b/game/hud/src/widgets/Social/components/OrdersGrid.tsx
@@ -1,0 +1,150 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * @Author: JB (jb@codecorsair.com)
+ * @Date: 2017-01-30 14:52:18
+ * @Last Modified by: JB (jb@codecorsair.com)
+ * @Last Modified time: 2017-02-27 11:49:08
+ */
+
+import * as React from 'react';
+import { graphql, InjectedGraphQLProps } from 'react-apollo';
+import { connect } from 'react-redux';
+import gql from 'graphql-tag';
+import { StyleSheet, css, StyleDeclaration } from 'aphrodite';
+import { Spinner, ColumnDefinition } from 'camelot-unchained';
+import GridViewPager from './GridViewPager';
+import GroupTitle from './GroupTitle';
+
+export interface OrdersGridStyle extends StyleDeclaration {
+  container : React.CSSProperties;
+}
+
+export const defaultOrdersGridStyle : OrdersGridStyle = {
+  container: {
+    flex: '1 1 auto',
+    display: 'flex',
+    flexDirection: 'column'
+  },
+};
+
+export interface OrdersGridQuery {
+  orders: {
+    totalCount: number;
+    data: {
+      id: string;
+      name: string;
+    }[]
+  }
+}
+
+export interface OrdersGridProps extends InjectedGraphQLProps<OrdersGridQuery> {
+  styles?: Partial<OrdersGridStyle>;
+  columnDefinitions?: ColumnDefinition[];
+  shard: number;
+  skip: number;
+  itemsPerPage: number;
+  filter: string;
+  gotoPage: (page: number) => void;
+};
+
+function stricmp(a: string, b: string) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  return a < b ? -1 : b > a ? 1 : 0;
+}
+
+function datecmp(a: string, b: string) {
+  const da = new Date(a);
+  const db = new Date(b);
+  return da < db ? -1 : da > db ? 1 : 0;
+}
+
+export const defaultOrdersGridColumnDefinitions = [
+  {
+    key: (m: {name: string}) => m.name,
+    title: 'Name',
+    sortable: true,
+    sortFunction: (a: {name: string}, b: {name: string}) => stricmp(a.name, b.name),
+    style: { width: '40%' },
+  },
+  {
+    key: (m: {realm: string}) => m.realm,
+    title: 'Realm',
+    sortable: true,
+    sortFunction: (a: {realm: string}, b: {realm: string}) => stricmp(a.realm, b.realm),
+    style: { width: '15%' },
+  },
+  {
+    key: (m: {creator: string}) => m.creator,
+    title: 'Creator',
+    sortable: true,
+    sortFunction: (a: {creator: string}, b: {creator: string}) => stricmp(a.creator, b.creator),
+    style: { width: '35%' },
+  },
+  {
+    key: (m: {created: string}) => new Date(m.created).toLocaleDateString(),
+    title: 'Created',
+    sortable: true,
+    sortFunction: (a: {created: string}, b: {created: string}) => datecmp(a.created, b.created),
+    style: { width: '10%' },
+  },
+];
+
+const OrdersGrid = (props : OrdersGridProps) => {
+
+  const ss = StyleSheet.create(defaultOrdersGridStyle);
+  const custom = StyleSheet.create(props.styles || {});
+  const columnDefs = props.columnDefinitions || defaultOrdersGridColumnDefinitions;
+
+  return (
+    <div className={css(ss.container)}>
+      { props.data.orders ?
+        <GridViewPager
+          /* Pager Props */
+          gotoPage={props.gotoPage}
+          total={props.data.orders.totalCount}
+          currentPage={props.skip/props.itemsPerPage}
+          /* GridView Props */
+          itemsPerPage={props.itemsPerPage}
+          items={props.data.orders.data}
+          columnDefinitions={columnDefs}
+          renderData={{ refetch: props.data.refetch }}
+          />
+      : <Spinner/>
+      }
+    </div>
+  )
+};
+
+const query = gql`
+  query OrdersGrid($shard: Int!, $count: Int!, $skip: Int!, $filter: String!) {
+    orders(shard: $shard, count: $count, skip: $skip, filter: $filter, includeDisbanded: false)  {
+      totalCount,
+      data {
+        id
+        name
+        realm
+        created
+        creator
+      }
+    }
+  }
+`;
+
+const options = (props: OrdersGridProps) => {
+  return {
+    variables: {
+      filter: props.filter||"",
+      shard: props.shard|0,
+      skip: props.skip|0,
+      count: props.itemsPerPage|0,
+    }
+  }
+};
+
+const OrdersGridWithQL = graphql(query, { options: options })(OrdersGrid);
+export default OrdersGridWithQL;
+

--- a/game/hud/src/widgets/Social/components/OrdersList.tsx
+++ b/game/hud/src/widgets/Social/components/OrdersList.tsx
@@ -3,10 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * @Author: JB (jb@codecorsair.com)
- * @Date: 2017-01-30 14:52:18
- * @Last Modified by: JB (jb@codecorsair.com)
- * @Last Modified time: 2017-02-27 11:49:08
+ * @Author: Mehuge (mehuge@sorcerer.co.uk)
+ * @Date: 2017-03-08
  */
 
 import * as React from 'react';

--- a/game/hud/src/widgets/Social/components/OrdersList.tsx
+++ b/game/hud/src/widgets/Social/components/OrdersList.tsx
@@ -46,7 +46,7 @@ class OrdersList extends React.Component<OrdersListProps, OrdersListState> {
     super(props);
     this.state = {
       page: 0,
-      itemsPerPage: 10,       // TODO: Should be calculated to fit space
+      itemsPerPage: 25,       // TODO: Should be calculated to fit space
       filter: '',
       sort: '',
       reverse: false

--- a/game/hud/src/widgets/Social/components/OrdersList.tsx
+++ b/game/hud/src/widgets/Social/components/OrdersList.tsx
@@ -30,6 +30,7 @@ export const defaultOrdersListStyle : OrdersListStyle = {
 
 export interface OrdersListProps {
   refetch: () => void;
+  styles?: Partial<OrdersListStyle>;
 };
 
 interface OrdersListState {
@@ -58,9 +59,10 @@ class OrdersList extends React.Component<OrdersListProps, OrdersListState> {
 
   render() {
     const ss = StyleSheet.create(defaultOrdersListStyle);
+    const custom = StyleSheet.create(this.props.styles || {});
     const skip = this.state.itemsPerPage * this.state.page;
     return (
-      <div className={css(ss.container)}>
+      <div className={css(ss.container, custom.container)}>
         <GroupTitle refetch={this.props.refetch}>
           Orders
         </GroupTitle>

--- a/game/hud/src/widgets/Social/components/OrdersList.tsx
+++ b/game/hud/src/widgets/Social/components/OrdersList.tsx
@@ -1,0 +1,86 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * @Author: JB (jb@codecorsair.com)
+ * @Date: 2017-01-30 14:52:18
+ * @Last Modified by: JB (jb@codecorsair.com)
+ * @Last Modified time: 2017-02-27 11:49:08
+ */
+
+import * as React from 'react';
+import { StyleSheet, css, StyleDeclaration } from 'aphrodite';
+import GroupTitle from './GroupTitle';
+import OrdersGrid from './OrdersGrid';
+import { client, Input } from 'camelot-unchained';
+
+export interface OrdersListStyle extends StyleDeclaration {
+  container : React.CSSProperties;
+  filterBox : React.CSSProperties;
+};
+export const defaultOrdersListStyle : OrdersListStyle = {
+  container: {
+    flex: '1 1 auto',
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  filterBox: {
+    padding: '0.5em'
+  }
+};
+
+export interface OrdersListProps {
+  refetch: () => void;
+};
+
+interface OrdersListState {
+  page: number;
+  itemsPerPage: number;
+  filter: string;
+}
+
+class OrdersList extends React.Component<OrdersListProps, OrdersListState> {
+  searchRef: HTMLInputElement = null;
+  constructor(props: OrdersListProps) {
+    super(props);
+    this.state = {
+      page: 0,
+      itemsPerPage: 25,       // TODO: Should be calculated to fit space
+      filter: ''
+    };
+  }
+  onFilterChanged = (e: any) => {
+    this.setState({ filter: this.searchRef.value.toLowerCase() });
+  }
+
+  render() {
+    const ss = StyleSheet.create(defaultOrdersListStyle);
+    const skip = this.state.itemsPerPage * this.state.page;
+    return (
+      <div className={css(ss.container)}>
+        <GroupTitle refetch={this.props.refetch}>
+          Orders
+        </GroupTitle>
+        <div className={css(ss.filterBox)}>
+          <Input
+            type='text'
+            placeholder='Seach for an order ...'
+            inputRef={r => this.searchRef = r}
+            onChange={this.onFilterChanged}
+            />
+        </div>
+        <OrdersGrid
+          shard={client.shardID}
+          skip={skip}
+          filter={this.state.filter}
+          itemsPerPage={this.state.itemsPerPage}
+          gotoPage={(page: number) => {
+            this.setState({ page: page });
+          }} />
+      </div>
+    );
+  }
+};
+
+export default OrdersList;

--- a/game/hud/src/widgets/Social/components/OrdersList.tsx
+++ b/game/hud/src/widgets/Social/components/OrdersList.tsx
@@ -38,6 +38,8 @@ interface OrdersListState {
   page: number;
   itemsPerPage: number;
   filter: string;
+  sort: string;
+  reverse: boolean;
 }
 
 class OrdersList extends React.Component<OrdersListProps, OrdersListState> {
@@ -46,8 +48,10 @@ class OrdersList extends React.Component<OrdersListProps, OrdersListState> {
     super(props);
     this.state = {
       page: 0,
-      itemsPerPage: 25,       // TODO: Should be calculated to fit space
-      filter: ''
+      itemsPerPage: 10,       // TODO: Should be calculated to fit space
+      filter: '',
+      sort: '',
+      reverse: false
     };
   }
   onFilterChanged = (e: any) => {
@@ -77,7 +81,16 @@ class OrdersList extends React.Component<OrdersListProps, OrdersListState> {
           itemsPerPage={this.state.itemsPerPage}
           gotoPage={(page: number) => {
             this.setState({ page: page });
-          }} />
+          }}
+          sort={this.state.sort} reverse={this.state.reverse}
+          orderBy={(name: string, asc: boolean) => {
+            // sort
+            this.setState({
+              sort: name,
+              reverse: !asc
+            } as OrdersListState);
+          }}
+          />
       </div>
     );
   }

--- a/game/hud/src/widgets/Social/components/SocialMain.tsx
+++ b/game/hud/src/widgets/Social/components/SocialMain.tsx
@@ -31,7 +31,7 @@ import SocialNav from './SocialNav';
 export interface SocialMainStyle extends StyleDeclaration {
   container: React.CSSProperties;
   closeButton: React.CSSProperties;
-  content: React.CSSProperties; 
+  content: React.CSSProperties;
 }
 
 export const defaultSocialMainStyle: SocialMainStyle = {
@@ -171,7 +171,7 @@ class SocialMain extends React.Component<Partial<SocialMainProps>, SocialMainSta
         break;
     }
     }
-    
+
     return (
       <div className={css(ss.container, custom.container)}>
 

--- a/game/hud/src/widgets/Social/services/session/nav/testNav.tsx
+++ b/game/hud/src/widgets/Social/services/session/nav/testNav.tsx
@@ -109,7 +109,7 @@ export default function() {
               displayName: 'Browse',
               icon: <i className='fa fa-bars'></i>,
               enabled: true,
-              display: (social: ql.MySocialQuery) => false,
+              display: (social: ql.MySocialQuery) => true,
               address: {
                 kind: 'Primary',
                 category: SocialCategory.Order,

--- a/library/package.json
+++ b/library/package.json
@@ -81,7 +81,7 @@
     "node-sass": "^3.8.0",
     "npm-watch": "^0.1.4",
     "typedoc": "^10.5.2",
-    "typescript": "^2.1.6",
+    "typescript": "2.1.6",
     "typings": "^1.3.2"
   }
 }

--- a/library/src/components/GridView.tsx
+++ b/library/src/components/GridView.tsx
@@ -160,11 +160,6 @@ export class GridViewImpl<P extends GridViewProps, S extends GridViewState> exte
       sortedItems: items,
       page: 0,
     } as S;
-    (this.state as S).page | 0;
-  }
-
-  public get customPager() : any {      // TODO Type it
-    return null;
   }
 
   componentWillReceiveProps = (nextProps: P) => {
@@ -310,8 +305,8 @@ export class GridViewImpl<P extends GridViewProps, S extends GridViewState> exte
   }
 
   renderGrid = (ss: GridViewStyle, custom: Partial<GridViewStyle>) => {
-    var state = this.state as S;
-    var startIndex = state.page * state.itemsPerPage;
+    const state = this.state as S;
+    const startIndex = state.page * state.itemsPerPage;
     const rows: JSX.Element[] = [];
 
     for (let index = startIndex;
@@ -327,6 +322,7 @@ export class GridViewImpl<P extends GridViewProps, S extends GridViewState> exte
       </div>
     )
   }
+
   renderPagination = (ss: GridViewStyle, custom: Partial<GridViewStyle>) => {
     const state = this.state as S;
     const itemCount = this.getItemCount();

--- a/library/src/util/compare.ts
+++ b/library/src/util/compare.ts
@@ -1,0 +1,22 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * @Author: Mehuge (mehuge@sorcerer.co.uk)
+ * @Date: 2017-03-08 23:42:32
+ * @Last Modified by: Mehuge (mehuge@sorcerer.co.uk)
+ * @Last Modified time: 2017-03-08 23:43:16
+ */
+
+export function stricmp(a: string, b: string) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  return a < b ? -1 : b > a ? 1 : 0;
+}
+
+export function datecmp(a: string, b: string) {
+  const da = new Date(a);
+  const db = new Date(b);
+  return da < db ? -1 : da > db ? 1 : 0;
+}

--- a/library/src/util/index.ts
+++ b/library/src/util/index.ts
@@ -3,10 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * @Author: JB (jb@codecorsair.com) 
- * @Date: 2016-10-12 23:59:34 
- * @Last Modified by: JB (jb@codecorsair.com)
- * @Last Modified time: 2017-02-17 17:38:05
+ * @Author: JB (jb@codecorsair.com)
+ * @Date: 2016-10-12 23:59:34
+ * @Last Modified by: Mehuge (mehuge@sorcerer.co.uk)
+ * @Last Modified time: 2017-03-08 23:44:03
  */
 
 export * from './arrayUtils';
@@ -14,6 +14,7 @@ export * from './objectUtils';
 export * from './eventMapper';
 export * from './reduxUtils';
 export * from './layoutLib';
+export * from './compare';
 
 import stringContains from './stringContains';
 import * as KeyCodes from './keyCodes';


### PR DESCRIPTION
Notes:

1. Column sorting on `GridView` has been changed to support only a single column.  This is because the multi-column sorting logic wasn't working, and would be complicated to make it work, so for now, we will go with single column sorting.

2. Column sorting has now been added to the Orders listing.

3. A subtle behaviour of `GridViewPager` that isn't obvious but is important to make it work deserves a bit of explanation.  Using `GridViewPager` we only ever supply a single page of data to the underlying `GridViewImpl`, yet we have page numbers and a pager UI.  How does GridView know to ignore the page number when working out what index to display data from?
Well, in fact it doesn't.  It still does `startIndex = this.state.page * this.props.itemsPerPage` but when using `GridViewPager` which overrides `goToPage()`, `this.state.page` is never updated so remains at zero.  The pager UI continues to work and know what page is the current page because `GridViewPager` overrides `getCurrentPage()` and provides its own page number.