### PR TITLE
Return parsed CSE Error object

### DIFF
--- a/library/src/webAPI/controllers/Characters.ts
+++ b/library/src/webAPI/controllers/Characters.ts
@@ -8,38 +8,37 @@ import { AxiosRequestConfig, Promise } from 'axios';
 import { create } from '../../util/apisaucelite';
 import createOptions from '../createOptions';
 import { Character } from '../definitions';
-
+import { BadRequest, ExecutionError, NotAllowed, ServiceUnavailable, Unauthorized } from '../apierrors';
 
 export function getCharactersV1() {
-  return create(createOptions()).call('v1/characters/getAll', { 
+  return create(createOptions()).call('v1/characters/getAll', {
   });
 }
 
 export function getCharactersOnShardV1(shardID: number) {
-  return create(createOptions()).call('v1/characters/getAllOnShard', { 
+  return create(createOptions()).call('v1/characters/getAllOnShard', {
     shardID: shardID
   });
 }
 
 export function getCharacterV1(shardID: number, characterID: string) {
-  return create(createOptions()).call('v1/characters/get', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/characters/get', {
+    shardID: shardID,
     characterID: characterID
   });
 }
 
 export function deleteCharacterV1(shardID: number, characterID: string) {
-  return create(createOptions()).call('v1/characters/delete', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/characters/delete', {
+    shardID: shardID,
     characterID: characterID
   });
 }
 
 export function createCharacterV1(shardID: number, character: Character) {
-  return create(createOptions()).call('v1/characters/create', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/characters/create', {
+    shardID: shardID,
     character: character
   });
 }
 
- 

--- a/library/src/webAPI/controllers/Content.ts
+++ b/library/src/webAPI/controllers/Content.ts
@@ -8,21 +8,20 @@ import { AxiosRequestConfig, Promise } from 'axios';
 import { create } from '../../util/apisaucelite';
 import createOptions from '../createOptions';
 import { Character } from '../definitions';
-
+import { BadRequest, ExecutionError, NotAllowed, ServiceUnavailable, Unauthorized } from '../apierrors';
 
 export function messageOfTheDayV1() {
-  return create(createOptions()).get('v1/messageoftheday', { 
+  return create(createOptions()).get('v1/messageoftheday', {
   });
 }
 
 export function patcherHeroContentV1() {
-  return create(createOptions()).get('v1/patcherherocontent', { 
+  return create(createOptions()).get('v1/patcherherocontent', {
   });
 }
 
 export function patcherAlertsV1() {
-  return create(createOptions()).get('v1/patcheralerts', { 
+  return create(createOptions()).get('v1/patcheralerts', {
   });
 }
 
- 

--- a/library/src/webAPI/controllers/GameData.ts
+++ b/library/src/webAPI/controllers/GameData.ts
@@ -8,43 +8,42 @@ import { AxiosRequestConfig, Promise } from 'axios';
 import { create } from '../../util/apisaucelite';
 import createOptions from '../createOptions';
 import { Character } from '../definitions';
-
+import { BadRequest, ExecutionError, NotAllowed, ServiceUnavailable, Unauthorized } from '../apierrors';
 
 export function getFactionInfoV1() {
-  return create(createOptions()).get('v1/gamedata/factionInfo', { 
+  return create(createOptions()).get('v1/gamedata/factionInfo', {
   });
 }
 
 export function getFactionsV1() {
-  return create(createOptions()).get('v1/gamedata/factions', { 
+  return create(createOptions()).get('v1/gamedata/factions', {
   });
 }
 
 export function getAttributeInfoV1(shard: number) {
-  return create(createOptions()).get('v1/gamedata/attributeInfo', { 
+  return create(createOptions()).get('v1/gamedata/attributeInfo', {
     shard: shard
   });
 }
 
 export function getArchetypesV1() {
-  return create(createOptions()).get('v1/gamedata/archetypes', { 
+  return create(createOptions()).get('v1/gamedata/archetypes', {
   });
 }
 
 export function getRacesV1() {
-  return create(createOptions()).get('v1/gamedata/races', { 
+  return create(createOptions()).get('v1/gamedata/races', {
   });
 }
 
 export function getAttributeOffsetsV1(shard: number) {
-  return create(createOptions()).get('v1/gamedata/attributeOffsets', { 
+  return create(createOptions()).get('v1/gamedata/attributeOffsets', {
     shard: shard
   });
 }
 
 export function getOrderPermissionsV1() {
-  return create(createOptions()).get('v1/gamedata/orderPermissions', { 
+  return create(createOptions()).get('v1/gamedata/orderPermissions', {
   });
 }
 
- 

--- a/library/src/webAPI/controllers/Groups.ts
+++ b/library/src/webAPI/controllers/Groups.ts
@@ -3,132 +3,132 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
+
 import { AxiosRequestConfig, Promise } from 'axios';
 import { create } from '../../util/apisaucelite';
 import createOptions from '../createOptions';
 import { Character } from '../definitions';
-
+import { BadRequest, ExecutionError, NotAllowed, ServiceUnavailable, Unauthorized } from '../apierrors';
 
 export function getInvitesForCharacterV1(shardID: number, characterID: string) {
-  return create(createOptions()).call('v1/groups/getInvitesForCharacter', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/groups/getInvitesForCharacter', {
+    shardID: shardID,
     characterID: characterID
   });
 }
 
 export function createRankV1(shardID: number, characterID: string, groupID: string, name: string, level: number, permissions: string[]) {
-  return create(createOptions()).call('v1/groups/createRank', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
-    name: name, 
-    level: level, 
+  return create(createOptions()).call('v1/groups/createRank', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
+    name: name,
+    level: level,
     permissions: permissions
   });
 }
 
 export function removeRankV1(shardID: number, characterID: string, groupID: string, name: string) {
-  return create(createOptions()).call('v1/groups/removeRank', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
+  return create(createOptions()).call('v1/groups/removeRank', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
     name: name
   });
 }
 
 export function renameRankV1(shardID: number, characterID: string, groupID: string, name: string, newName: string) {
-  return create(createOptions()).call('v1/groups/renameRank', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
-    name: name, 
+  return create(createOptions()).call('v1/groups/renameRank', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
+    name: name,
     newName: newName
   });
 }
 
 export function addRankPermissionsV1(shardID: number, characterID: string, groupID: string, name: string, permissions: string[]) {
-  return create(createOptions()).call('v1/groups/addRankPermissions', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
-    name: name, 
+  return create(createOptions()).call('v1/groups/addRankPermissions', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
+    name: name,
     permissions: permissions
   });
 }
 
 export function removeRankPermissionsV1(shardID: number, characterID: string, groupID: string, name: string, permissions: string[]) {
-  return create(createOptions()).call('v1/groups/removeRankPermissions', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
-    name: name, 
+  return create(createOptions()).call('v1/groups/removeRankPermissions', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
+    name: name,
     permissions: permissions
   });
 }
 
 export function setRankPermissionsV1(shardID: number, characterID: string, groupID: string, name: string, permissions: string[]) {
-  return create(createOptions()).call('v1/groups/setRankPermissions', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
-    name: name, 
+  return create(createOptions()).call('v1/groups/setRankPermissions', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
+    name: name,
     permissions: permissions
   });
 }
 
 export function setRankLevelV1(shardID: number, characterID: string, groupID: string, name: string, level: number) {
-  return create(createOptions()).call('v1/groups/setRankLevel', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
-    name: name, 
+  return create(createOptions()).call('v1/groups/setRankLevel', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
+    name: name,
     level: level
   });
 }
 
 export function assignRankV1(shardID: number, characterID: string, groupID: string, targetID: string, rankName: string) {
-  return create(createOptions()).call('v1/groups/assignRank', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
-    targetID: targetID, 
+  return create(createOptions()).call('v1/groups/assignRank', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
+    targetID: targetID,
     rankName: rankName
   });
 }
 
 export function kickV1(shardID: number, characterID: string, groupID: string, targetID: string) {
-  return create(createOptions()).call('v1/groups/kick', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
+  return create(createOptions()).call('v1/groups/kick', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
     targetID: targetID
   });
 }
 
 export function inviteV1(shardID: number, characterID: string, groupID: string, targetID: string) {
-  return create(createOptions()).call('v1/groups/invite', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
+  return create(createOptions()).call('v1/groups/invite', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
     targetID: targetID
   });
 }
 
 export function inviteByNameV1(shardID: number, characterID: string, groupID: string, targetName: string) {
-  return create(createOptions()).call('v1/groups/inviteByName', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
+  return create(createOptions()).call('v1/groups/inviteByName', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
     targetName: targetName
   });
 }
 
 export function acceptInviteV1(shardID: number, characterID: string, groupID: string, inviteCode: string) {
-  return create(createOptions()).call('v1/groups/acceptInvite', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    groupID: groupID, 
+  return create(createOptions()).call('v1/groups/acceptInvite', {
+    shardID: shardID,
+    characterID: characterID,
+    groupID: groupID,
     inviteCode: inviteCode
   });
 }

--- a/library/src/webAPI/controllers/Orders.ts
+++ b/library/src/webAPI/controllers/Orders.ts
@@ -3,125 +3,125 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
+
 import { AxiosRequestConfig, Promise } from 'axios';
 import { create } from '../../util/apisaucelite';
 import createOptions from '../createOptions';
 import { Character } from '../definitions';
-
+import { BadRequest, ExecutionError, NotAllowed, ServiceUnavailable, Unauthorized } from '../apierrors';
 
 export function createV1(shardID: number, characterID: string, name: string) {
-  return create(createOptions()).call('v1/orders/create', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/orders/create', {
+    shardID: shardID,
+    characterID: characterID,
     name: name
   });
 }
 
 export function createRankV1(shardID: number, characterID: string, name: string, level: number, permissions: string[]) {
-  return create(createOptions()).call('v1/orders/createRank', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    name: name, 
-    level: level, 
+  return create(createOptions()).call('v1/orders/createRank', {
+    shardID: shardID,
+    characterID: characterID,
+    name: name,
+    level: level,
     permissions: permissions
   });
 }
 
 export function removeRankV1(shardID: number, characterID: string, name: string) {
-  return create(createOptions()).call('v1/orders/removeRank', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/orders/removeRank', {
+    shardID: shardID,
+    characterID: characterID,
     name: name
   });
 }
 
 export function inviteV1(shardID: number, characterID: string, targetID: string) {
-  return create(createOptions()).call('v1/orders/inviteByID', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/orders/inviteByID', {
+    shardID: shardID,
+    characterID: characterID,
     targetID: targetID
   });
 }
 
 export function inviteByNameV1(shardID: number, characterID: string, targetName: string) {
-  return create(createOptions()).call('v1/orders/inviteByName', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/orders/inviteByName', {
+    shardID: shardID,
+    characterID: characterID,
     targetName: targetName
   });
 }
 
 export function acceptInvite(shardID: number, characterID: string, orderID: string, inviteCode: string) {
-  return create(createOptions()).call('v1/orders/acceptInvite', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    orderID: orderID, 
+  return create(createOptions()).call('v1/orders/acceptInvite', {
+    shardID: shardID,
+    characterID: characterID,
+    orderID: orderID,
     inviteCode: inviteCode
   });
 }
 
 export function kickV1(shardID: number, characterID: string, targetID: string) {
-  return create(createOptions()).call('v1/orders/kick', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/orders/kick', {
+    shardID: shardID,
+    characterID: characterID,
     targetID: targetID
   });
 }
 
 export function abandonV1(shardID: number, characterID: string) {
-  return create(createOptions()).call('v1/orders/abandon', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/orders/abandon', {
+    shardID: shardID,
     characterID: characterID
   });
 }
 
 export function disbandV1(shardID: number, characterID: string) {
-  return create(createOptions()).call('v1/orders/disband', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/orders/disband', {
+    shardID: shardID,
     characterID: characterID
   });
 }
 
 export function renameRankV1(shardID: number, characterID: string, name: string, newName: string) {
-  return create(createOptions()).call('v1/orders/renameRank', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    name: name, 
+  return create(createOptions()).call('v1/orders/renameRank', {
+    shardID: shardID,
+    characterID: characterID,
+    name: name,
     newName: newName
   });
 }
 
 export function addRankPermissionsV1(shardID: number, characterID: string, name: string, permissions: string[]) {
-  return create(createOptions()).call('v1/orders/addRankPermissions', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    name: name, 
+  return create(createOptions()).call('v1/orders/addRankPermissions', {
+    shardID: shardID,
+    characterID: characterID,
+    name: name,
     permissions: permissions
   });
 }
 
 export function removeRankPermissionsV1(shardID: number, characterID: string, name: string, permissions: string[]) {
-  return create(createOptions()).call('v1/orders/removeRankPermissions', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    name: name, 
+  return create(createOptions()).call('v1/orders/removeRankPermissions', {
+    shardID: shardID,
+    characterID: characterID,
+    name: name,
     permissions: permissions
   });
 }
 
 export function changeRankLevelV1(shardID: number, characterID: string, name: string, level: number) {
-  return create(createOptions()).call('v1/orders/changeRankLevel', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    name: name, 
+  return create(createOptions()).call('v1/orders/changeRankLevel', {
+    shardID: shardID,
+    characterID: characterID,
+    name: name,
     level: level
   });
 }
 
 export function getMyRankV1(shardID: number, characterID: string) {
-  return create(createOptions()).call('v1/orders/getMyRank', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/orders/getMyRank', {
+    shardID: shardID,
     characterID: characterID
   });
 }

--- a/library/src/webAPI/controllers/Plots.ts
+++ b/library/src/webAPI/controllers/Plots.ts
@@ -8,54 +8,53 @@ import { AxiosRequestConfig, Promise } from 'axios';
 import { create } from '../../util/apisaucelite';
 import createOptions from '../createOptions';
 import { Character } from '../definitions';
-
+import { BadRequest, ExecutionError, NotAllowed, ServiceUnavailable, Unauthorized } from '../apierrors';
 
 export function releasePlotV1(shardID: number, characterID: string, loginToken: string, entityID: string) {
-  return create(createOptions()).call('v1/plot/releasePlot', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    loginToken: loginToken, 
+  return create(createOptions()).call('v1/plot/releasePlot', {
+    shardID: shardID,
+    characterID: characterID,
+    loginToken: loginToken,
     entityID: entityID
   });
 }
 
 export function modifyPermissionsV1(shardID: number, characterID: string, loginToken: string, entityID: string, newPermissions: number) {
-  return create(createOptions()).call('v1/plot/modifyPermissions', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    loginToken: loginToken, 
-    entityID: entityID, 
+  return create(createOptions()).call('v1/plot/modifyPermissions', {
+    shardID: shardID,
+    characterID: characterID,
+    loginToken: loginToken,
+    entityID: entityID,
     newPermissions: newPermissions
   });
 }
 
 export function removeQueuedBlueprintV1(shardID: number, characterID: string, loginToken: string, entityID: string, indexToRemove: number) {
-  return create(createOptions()).call('v1/plot/removeQueuedBlueprint', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    loginToken: loginToken, 
-    entityID: entityID, 
+  return create(createOptions()).call('v1/plot/removeQueuedBlueprint', {
+    shardID: shardID,
+    characterID: characterID,
+    loginToken: loginToken,
+    entityID: entityID,
     indexToRemove: indexToRemove
   });
 }
 
 export function reorderQueueV1(shardID: number, characterID: string, loginToken: string, entityID: string, indexToMove: number, destinationIndex: number) {
-  return create(createOptions()).call('v1/plot/reorderQueue', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    loginToken: loginToken, 
-    entityID: entityID, 
-    indexToMove: indexToMove, 
+  return create(createOptions()).call('v1/plot/reorderQueue', {
+    shardID: shardID,
+    characterID: characterID,
+    loginToken: loginToken,
+    entityID: entityID,
+    indexToMove: indexToMove,
     destinationIndex: destinationIndex
   });
 }
 
 export function getQueueStatusV1(shardID: number, characterID: string, loginToken: string) {
-  return create(createOptions()).call('v1/plot/getQueueStatus', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/plot/getQueueStatus', {
+    shardID: shardID,
+    characterID: characterID,
     loginToken: loginToken
   });
 }
 
- 

--- a/library/src/webAPI/controllers/Presence.ts
+++ b/library/src/webAPI/controllers/Presence.ts
@@ -8,13 +8,12 @@ import { AxiosRequestConfig, Promise } from 'axios';
 import { create } from '../../util/apisaucelite';
 import createOptions from '../createOptions';
 import { Character } from '../definitions';
-
+import { BadRequest, ExecutionError, NotAllowed, ServiceUnavailable, Unauthorized } from '../apierrors';
 
 export function getStartingServer(shardID: number, characterID: string) {
-  return create(createOptions()).get('v1/presence/startingServer/{shardID}/{characterID}', { 
-    shardID: shardID, 
+  return create(createOptions()).get('v1/presence/startingServer/{shardID}/{characterID}', {
+    shardID: shardID,
     characterID: characterID
   });
 }
 
- 

--- a/library/src/webAPI/controllers/ServerListHelper.ts
+++ b/library/src/webAPI/controllers/ServerListHelper.ts
@@ -8,24 +8,23 @@ import { AxiosRequestConfig, Promise } from 'axios';
 import { create } from '../../util/apisaucelite';
 import createOptions from '../createOptions';
 import { Character } from '../definitions';
-
+import { BadRequest, ExecutionError, NotAllowed, ServiceUnavailable, Unauthorized } from '../apierrors';
 
 export function getServersV1() {
-  return create(createOptions()).get('v1/servers/getAll', { 
+  return create(createOptions()).get('v1/servers/getAll', {
   });
 }
 
 export function getServersForChannelV1(channelId: number) {
-  return create(createOptions()).get('v1/servers/getForChannel', { 
+  return create(createOptions()).get('v1/servers/getForChannel', {
     channelId: channelId
   });
 }
 
 export function getHostsForServerV1(channelId: number, name: string) {
-  return create(createOptions()).get('v1/servers/getHosts', { 
-    channelId: channelId, 
+  return create(createOptions()).get('v1/servers/getHosts', {
+    channelId: channelId,
     name: name
   });
 }
 
- 

--- a/library/src/webAPI/controllers/Traits.ts
+++ b/library/src/webAPI/controllers/Traits.ts
@@ -3,15 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
- 
+
 import { AxiosRequestConfig, Promise } from 'axios';
 import { create } from '../../util/apisaucelite';
 import createOptions from '../createOptions';
 import { Character } from '../definitions';
-
+import { BadRequest, ExecutionError, NotAllowed, ServiceUnavailable, Unauthorized } from '../apierrors';
 
 export function getTraitsV1(shardID: number) {
-  return create(createOptions()).get('v1/traits', { 
+  return create(createOptions()).get('v1/traits', {
     shardID: shardID
   });
 }

--- a/library/src/webAPI/controllers/Warbands.ts
+++ b/library/src/webAPI/controllers/Warbands.ts
@@ -8,271 +8,270 @@ import { AxiosRequestConfig, Promise } from 'axios';
 import { create } from '../../util/apisaucelite';
 import createOptions from '../createOptions';
 import { Character } from '../definitions';
-
+import { BadRequest, ExecutionError, NotAllowed, ServiceUnavailable, Unauthorized } from '../apierrors';
 
 export function createV1(shardID: number, characterID: string) {
-  return create(createOptions()).call('v1/warbands/create', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/warbands/create', {
+    shardID: shardID,
     characterID: characterID
   });
 }
 
 export function createWithNameV1(shardID: number, characterID: string, name: string) {
-  return create(createOptions()).call('v1/warbands/createWithName', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/createWithName', {
+    shardID: shardID,
+    characterID: characterID,
     name: name
   });
 }
 
 export function inviteV1(shardID: number, characterID: string, targetID: string) {
-  return create(createOptions()).call('v1/warbands/invite', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/invite', {
+    shardID: shardID,
+    characterID: characterID,
     targetID: targetID
   });
 }
 
 export function inviteByIDV1(shardID: number, characterID: string, targetID: string, warbandID: string) {
-  return create(createOptions()).call('v1/warbands/inviteWithID', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetID: targetID, 
+  return create(createOptions()).call('v1/warbands/inviteWithID', {
+    shardID: shardID,
+    characterID: characterID,
+    targetID: targetID,
     warbandID: warbandID
   });
 }
 
 export function inviteByNameV1(shardID: number, characterID: string, targetName: string) {
-  return create(createOptions()).call('v1/warbands/inviteByName', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/inviteByName', {
+    shardID: shardID,
+    characterID: characterID,
     targetName: targetName
   });
 }
 
 export function inviteByNameWithIDV1(shardID: number, characterID: string, targetName: string, warbandID: string) {
-  return create(createOptions()).call('v1/warbands/inviteByNameWithID', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetName: targetName, 
+  return create(createOptions()).call('v1/warbands/inviteByNameWithID', {
+    shardID: shardID,
+    characterID: characterID,
+    targetName: targetName,
     warbandID: warbandID
   });
 }
 
 export function joinWithInviteV1(shardID: number, warbandID: string, characterID: string, inviteCode: string) {
-  return create(createOptions()).call('v1/warbands/joinWithInvite', { 
-    shardID: shardID, 
-    warbandID: warbandID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/joinWithInvite', {
+    shardID: shardID,
+    warbandID: warbandID,
+    characterID: characterID,
     inviteCode: inviteCode
   });
 }
 
 export function joinV1(shardID: number, warbandID: string, characterID: string) {
-  return create(createOptions()).call('v1/warbands/join', { 
-    shardID: shardID, 
-    warbandID: warbandID, 
+  return create(createOptions()).call('v1/warbands/join', {
+    shardID: shardID,
+    warbandID: warbandID,
     characterID: characterID
   });
 }
 
 export function joinByNameV1(shardID: number, warbandName: string, characterID: string) {
-  return create(createOptions()).call('v1/warbands/joinByName', { 
-    shardID: shardID, 
-    warbandName: warbandName, 
+  return create(createOptions()).call('v1/warbands/joinByName', {
+    shardID: shardID,
+    warbandName: warbandName,
     characterID: characterID
   });
 }
 
 export function joinByNameWithInviteV1(shardID: number, warbandName: string, characterID: string, inviteCode: string) {
-  return create(createOptions()).call('v1/warbands/joinByNameWithInvite', { 
-    shardID: shardID, 
-    warbandName: warbandName, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/joinByNameWithInvite', {
+    shardID: shardID,
+    warbandName: warbandName,
+    characterID: characterID,
     inviteCode: inviteCode
   });
 }
 
 export function quitV1(shardID: number, characterID: string) {
-  return create(createOptions()).call('v1/warbands/quit', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/warbands/quit', {
+    shardID: shardID,
     characterID: characterID
   });
 }
 
 export function abandonByNameV1(shardID: number, characterID: string, warbandName: string) {
-  return create(createOptions()).call('v1/warbands/abandonByName', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/abandonByName', {
+    shardID: shardID,
+    characterID: characterID,
     warbandName: warbandName
   });
 }
 
 export function abandonV1(shardID: number, characterID: string) {
-  return create(createOptions()).call('v1/warbands/abandon', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/warbands/abandon', {
+    shardID: shardID,
     characterID: characterID
   });
 }
 
 export function abandonByIDV1(shardID: number, characterID: string, warbandID: string) {
-  return create(createOptions()).call('v1/warbands/abandonByID', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/abandonByID', {
+    shardID: shardID,
+    characterID: characterID,
     warbandID: warbandID
   });
 }
 
 export function setRankV1(shardID: number, characterID: string, targetID: string, rank: string) {
-  return create(createOptions()).call('v1/warbands/setRank', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetID: targetID, 
+  return create(createOptions()).call('v1/warbands/setRank', {
+    shardID: shardID,
+    characterID: characterID,
+    targetID: targetID,
     rank: rank
   });
 }
 
 export function setRankWithIDV1(shardID: number, characterID: string, targetID: string, rank: string, warbandID: string) {
-  return create(createOptions()).call('v1/warbands/setRankWithID', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetID: targetID, 
-    rank: rank, 
+  return create(createOptions()).call('v1/warbands/setRankWithID', {
+    shardID: shardID,
+    characterID: characterID,
+    targetID: targetID,
+    rank: rank,
     warbandID: warbandID
   });
 }
 
 export function setRankByNameV1(shardID: number, characterID: string, targetName: string, rank: string) {
-  return create(createOptions()).call('v1/warbands/setRankByName', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetName: targetName, 
+  return create(createOptions()).call('v1/warbands/setRankByName', {
+    shardID: shardID,
+    characterID: characterID,
+    targetName: targetName,
     rank: rank
   });
 }
 
 export function setRankByNameWithIDV1(shardID: number, characterID: string, targetName: string, rank: string, warbandID: string) {
-  return create(createOptions()).call('v1/warbands/setRankByNameWithID', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetName: targetName, 
-    rank: rank, 
+  return create(createOptions()).call('v1/warbands/setRankByNameWithID', {
+    shardID: shardID,
+    characterID: characterID,
+    targetName: targetName,
+    rank: rank,
     warbandID: warbandID
   });
 }
 
 export function setLeaderV1(shardID: number, characterID: string, targetID: string) {
-  return create(createOptions()).call('v1/warbands/setLeader', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/setLeader', {
+    shardID: shardID,
+    characterID: characterID,
     targetID: targetID
   });
 }
 
 export function setLeaderWithIDV1(shardID: number, characterID: string, targetID: string, warbandID: string) {
-  return create(createOptions()).call('v1/warbands/setLeaderWithID', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetID: targetID, 
+  return create(createOptions()).call('v1/warbands/setLeaderWithID', {
+    shardID: shardID,
+    characterID: characterID,
+    targetID: targetID,
     warbandID: warbandID
   });
 }
 
 export function setLeaderByNameV1(shardID: number, characterID: string, targetName: string) {
-  return create(createOptions()).call('v1/warbands/setLeaderByName', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/setLeaderByName', {
+    shardID: shardID,
+    characterID: characterID,
     targetName: targetName
   });
 }
 
 export function setLeaderByNameWithIDV1(shardID: number, characterID: string, targetName: string, warbandID: string) {
-  return create(createOptions()).call('v1/warbands/setLeaderByNameWithID', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetName: targetName, 
+  return create(createOptions()).call('v1/warbands/setLeaderByNameWithID', {
+    shardID: shardID,
+    characterID: characterID,
+    targetName: targetName,
     warbandID: warbandID
   });
 }
 
 export function setDisplayOrderV1(shardID: number, characterID: string, targetID: string, wantDisplayOrder: number) {
-  return create(createOptions()).call('v1/warbands/setDisplayOrder', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetID: targetID, 
+  return create(createOptions()).call('v1/warbands/setDisplayOrder', {
+    shardID: shardID,
+    characterID: characterID,
+    targetID: targetID,
     wantDisplayOrder: wantDisplayOrder
   });
 }
 
 export function setDisplayOrderWithIDV1(shardID: number, characterID: string, targetID: string, wantDisplayOrder: number, warbandID: string) {
-  return create(createOptions()).call('v1/warbands/setDisplayOrderWithID', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetID: targetID, 
-    wantDisplayOrder: wantDisplayOrder, 
+  return create(createOptions()).call('v1/warbands/setDisplayOrderWithID', {
+    shardID: shardID,
+    characterID: characterID,
+    targetID: targetID,
+    wantDisplayOrder: wantDisplayOrder,
     warbandID: warbandID
   });
 }
 
 export function kickV1(shardID: number, characterID: string, targetID: string) {
-  return create(createOptions()).call('v1/warbands/kick', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/kick', {
+    shardID: shardID,
+    characterID: characterID,
     targetID: targetID
   });
 }
 
 export function kicWithIDkV1(shardID: number, characterID: string, targetID: string, warbandID: string) {
-  return create(createOptions()).call('v1/warbands/kickWithID', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetID: targetID, 
+  return create(createOptions()).call('v1/warbands/kickWithID', {
+    shardID: shardID,
+    characterID: characterID,
+    targetID: targetID,
     warbandID: warbandID
   });
 }
 
 export function kickByNameV1(shardID: number, characterID: string, targetName: string) {
-  return create(createOptions()).call('v1/warbands/kickByName', { 
-    shardID: shardID, 
-    characterID: characterID, 
+  return create(createOptions()).call('v1/warbands/kickByName', {
+    shardID: shardID,
+    characterID: characterID,
     targetName: targetName
   });
 }
 
 export function kickByNameWithIDV1(shardID: number, characterID: string, targetName: string, warbandID: string) {
-  return create(createOptions()).call('v1/warbands/kickByNameWithID', { 
-    shardID: shardID, 
-    characterID: characterID, 
-    targetName: targetName, 
+  return create(createOptions()).call('v1/warbands/kickByNameWithID', {
+    shardID: shardID,
+    characterID: characterID,
+    targetName: targetName,
     warbandID: warbandID
   });
 }
 
 export function getInfoV1(shardID: number, warbandID: string) {
-  return create(createOptions()).call('v1/groups/getWarbandInfoByID', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/groups/getWarbandInfoByID', {
+    shardID: shardID,
     warbandID: warbandID
   });
 }
 
 export function getInfoByNameV1(shardID: number, warbandName: string) {
-  return create(createOptions()).call('v1/groups/getWarbandInfoByName', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/groups/getWarbandInfoByName', {
+    shardID: shardID,
     warbandName: warbandName
   });
 }
 
 export function getActiveInfoV1(shardID: number, characterID: string) {
-  return create(createOptions()).call('v1/groups/getMyActiveWarbandInfo', { 
-    shardID: shardID, 
+  return create(createOptions()).call('v1/groups/getMyActiveWarbandInfo', {
+    shardID: shardID,
     characterID: characterID
   });
 }
 
 export function getAllWarbandsOnShardV1(shardID: number) {
-  return create(createOptions()).call('v1/groups/getAllWarbands', { 
+  return create(createOptions()).call('v1/groups/getAllWarbands', {
     shardID: shardID
   });
 }
 
- 


### PR DESCRIPTION
This change detects a JSON response from the api server and returns the parsed JSON response in `response.error` or if a non-JSON response it returns a `response.error` object with Code and Message fields filled.

So in all cases, can do

```
if (response.error) {
  const { Code, Message } = response.error;
}
```

Where the API has returned a JSON response, the error object may also contain a ```FieldCodes``` array whose contents will include a `Code` and a `Message` and potentially other data depending on the main error code (`response.error.Code`).

Error types are defined by 'camelot-unchained/webAPI/apierrors'

Additional Notes:

`response.error` is only defined if there was an error and `response.ok` will also be `false`
