### PR TITLE
Handle missing response when parsing errors

### DIFF
--- a/library/src/util/apisaucelite.ts
+++ b/library/src/util/apisaucelite.ts
@@ -120,15 +120,22 @@ export const create = (config: CreateOptions) => {
     const stack = error.stack
     let err
 
-    // try and json parse the response, if successful, assume its
-    // the newer response type
-    if (error.response.headers['content-type'] == 'text/json') {
-      err = error.response.data;
+    if (error.response) {
+      // try and json parse the response, if successful, assume its
+      // the newer response type
+      if (error.response.headers && error.response.headers['content-type'] == 'text/json') {
+        err = error.response.data;
+      } else {
+        // old style error response, map to new style
+        err = {
+          Code: error.code || error.response.status,
+          Message: error.response.data || error.message,
+        }
+      }
     } else {
-      // old style error response, map to new style
       err = {
-        Code: error.code || error.response.status,
-        Message: error.response.data || error.message
+        Code: error.code,
+        Message: error.message,
       }
     }
 


### PR DESCRIPTION
Checks for a response and response headers before attempting to parse response as JSON to avoid throwing an exception under certain network conditions.  Fixes #102