### PR TITLE
Pause music while client is running

### DIFF
--- a/patcher/src/components/Sound/index.tsx
+++ b/patcher/src/components/Sound/index.tsx
@@ -67,10 +67,8 @@ export class Sound extends React.Component<SoundProps, SoundState> {
   }
 
   private playSound(name: string) {
-    console.log('SOUND: playSound playSound=' + this.props.soundsState.playSound);
     if (this.props.soundsState.playSound) {
       const id = generateID(7);
-      console.log('SOUND: playSound ' + name + ' id=' + id);
       this.setStateAsync({
         sounds: { ...this.state.sounds, [id]: name },
       });
@@ -87,7 +85,6 @@ export class Sound extends React.Component<SoundProps, SoundState> {
     const sounds = { ...this.state.sounds };
     delete sounds[id];
     delete this.audioRefs[id];
-    console.log('SOUND: sound finished id=' + id);
     this.setStateAsync({ sounds });
   }
 
@@ -187,18 +184,11 @@ export class Sound extends React.Component<SoundProps, SoundState> {
   }
 
   private componentDidUpdate() {
-    console.log('SOUND: componentDidUpdate:'
-      + ' playMusic=' + this.props.soundsState.playMusic
-      + ' playSound=' + this.props.soundsState.playSound
-      + ' paused=' + this.state.paused);
     if (this.bgRef) {
       const paused = this.state.paused || !this.props.soundsState.playMusic;
-      console.log('SOUND: pause/play? ' + paused);
       if (paused && !this.bgRef.paused) {
         this.pause(true);
-        console.log('SOUND: bgRef.pause()');
       } else if (!paused && this.bgRef.paused) {
-        console.log('SOUND: bgRef.play()');
         this.pause(false);
       }
     }

--- a/patcher/src/components/Sound/index.tsx
+++ b/patcher/src/components/Sound/index.tsx
@@ -5,8 +5,8 @@
  *
  * @Author: JB (jb@codecorsair.com)
  * @Date: 2016-09-06 17:53:23
- * @Last Modified by: Andrew L. Jackson (jacksonal300@gmail.com)
- * @Last Modified time: 2017-04-10 14:17:44
+ * @Last Modified by: Mehuge (mehuge@sorcerer.co.uk)
+ * @Last Modified time: 2017-04-14 21:50:05
  */
 
 import * as React from 'react';
@@ -21,8 +21,9 @@ export interface SoundProps {
 
 export interface SoundState {
   sounds: { [id: string]: string };
+  paused: boolean;
 }
- 
+
 const sounds = {
   select: 'sounds/UI_Menu_GenericSelect_v1_02.ogg',
   launchGame: 'sounds/UI_Patcher_PlayButton_v3.ogg',
@@ -39,30 +40,46 @@ const sounds = {
 export class Sound extends React.Component<SoundProps, SoundState> {
 
   private bgRef: HTMLAudioElement = null;
+  private evhs: any[] = [];       // event handlers
   private audioRefs: { [id: string]: HTMLAudioElement } = {};
 
   constructor(props: SoundProps) {
     super(props);
     this.state = {
       sounds: {},
+      paused: false,
     };
   }
 
   public render() {
     return (
       <div>
-        <audio src='sounds/patcher-theme.ogg' ref={r => this.bgRef = r }/>
-        {this.renderAudioElements()}     
+        <audio loop={true}
+               src='sounds/patcher-theme.ogg'
+               ref={r => this.bgRef = r }/>
+        {this.renderAudioElements()}
       </div>
     );
   }
 
+  private setStateAsync = (sparseState: any) => {
+    setTimeout(() => { this.setState(sparseState); },0);
+  }
+
   private playSound(name: string) {
+    console.log('SOUND: playSound playSound=' + this.props.soundsState.playSound);
     if (this.props.soundsState.playSound) {
       const id = generateID(7);
-      this.setState({
+      console.log('SOUND: playSound ' + name + ' id=' + id);
+      this.setStateAsync({
         sounds: { ...this.state.sounds, [id]: name },
       });
+    }
+  }
+
+  private pauseMusic(paused: boolean) {
+    if (this.state.paused !== paused) {
+      this.setStateAsync({ paused });
     }
   }
 
@@ -70,9 +87,8 @@ export class Sound extends React.Component<SoundProps, SoundState> {
     const sounds = { ...this.state.sounds };
     delete sounds[id];
     delete this.audioRefs[id];
-    this.setState({
-      sounds,
-    });
+    console.log('SOUND: sound finished id=' + id);
+    this.setStateAsync({ sounds });
   }
 
   private generateAudioElement = (sound: string, id: string) => {
@@ -83,37 +99,37 @@ export class Sound extends React.Component<SoundProps, SoundState> {
                       onEnded={() => this.onEnded(id)}
                       src={sounds.select}
                       ref={r => this.audioRefs[id] = r }/>;
-      case 'launch-game': 
+      case 'launch-game':
         return <audio key={id}
                       autoPlay
                       onEnded={() => this.onEnded(id)}
                       src={sounds.launchGame}
                       ref={r => this.audioRefs[id] = r }/>;
-      case 'patch-complete': 
+      case 'patch-complete':
         return <audio key={id}
                       autoPlay
                       onEnded={() => this.onEnded(id)}
                       src={sounds.patchComplete}
                       ref={r => this.audioRefs[id] = r }/>;
-      case 'select-change': 
+      case 'select-change':
         return <audio key={id}
                       autoPlay
                       onEnded={() => this.onEnded(id)}
                       src={sounds.selectChange}
                       ref={r => this.audioRefs[id] = r }/>;
-      case 'create-character': 
+      case 'create-character':
         return <audio key={id}
                       autoPlay
                       onEnded={() => this.onEnded(id)}
                       src={sounds.createCharacter}
                       ref={r => this.audioRefs[id] = r }/>;
-      case 'realm-select': 
+      case 'realm-select':
         return <audio key={id}
                       autoPlay
                       onEnded={() => this.onEnded(id)}
                       src={sounds.realmSelect}
                       ref={r => this.audioRefs[id] = r }/>;
-      case 'server-select': 
+      case 'server-select':
         return <audio key={id}
                       autoPlay
                       onEnded={() => this.onEnded(id)}
@@ -141,13 +157,49 @@ export class Sound extends React.Component<SoundProps, SoundState> {
     }
   }
 
-  private  componentDidUpdate() {
-    if (this.bgRef) {
-      if (!this.props.soundsState.playMusic && !this.bgRef.paused) {
+  private pause = (pause: boolean) => {
+    const fade = (from: number, to: number, increment: number, done?: () => void) => {
+      if (increment > 0 ? from < to : from > to) {
+        this.bgRef.volume = from;
+        setTimeout(() => fade(from + increment, to, increment, done), 100);
+      } else {
+        this.bgRef.volume = to;
+        if (done) done();
+      }
+    };
+    // Note:-
+    // When pausing due to play, we fade-out, and when finished playing we fade in.
+    // When muting, we mute immediately, but when unmuting we fade in (the quirk)
+    // This is because at the moment it isn't possible to differentiate between
+    // finishing playing and unmuting.
+    if (pause) {
+      if (this.props.soundsState.playMusic) {
+        // fade-out
+        fade(0.5, 0.0, -0.1, () => { this.bgRef.pause(); });
+      } else {
         this.bgRef.pause();
-      } else if (this.props.soundsState.playMusic && this.bgRef.paused) {
-        this.bgRef.play();
-        this.bgRef.volume = 0.5;
+      }
+    } else {
+      // fade-in
+      fade(0.0, 0.5, 0.05);
+      this.bgRef.play();
+    }
+  }
+
+  private componentDidUpdate() {
+    console.log('SOUND: componentDidUpdate:'
+      + ' playMusic=' + this.props.soundsState.playMusic
+      + ' playSound=' + this.props.soundsState.playSound
+      + ' paused=' + this.state.paused);
+    if (this.bgRef) {
+      const paused = this.state.paused || !this.props.soundsState.playMusic;
+      console.log('SOUND: pause/play? ' + paused);
+      if (paused && !this.bgRef.paused) {
+        this.pause(true);
+        console.log('SOUND: bgRef.pause()');
+      } else if (!paused && this.bgRef.paused) {
+        console.log('SOUND: bgRef.play()');
+        this.pause(false);
       }
     }
   }
@@ -159,13 +211,14 @@ export class Sound extends React.Component<SoundProps, SoundState> {
         this.bgRef.volume = 0.5;
       }
     }
-    events.on('play-sound', (name: string) => this.playSound(name));
+    this.evhs.push(events.on('play-sound', (name: string) => this.playSound(name)));
+    this.evhs.push(events.on('pause-music', (paused: boolean) => this.pauseMusic(paused)));
   }
 
-  private componentDidUnMount() {
-    events.off('play-sound');
+  private componentWillUnMount() {
+    this.evhs.map((h: any) => events.off(h));
   }
-  
+
   private renderAudioElements = () => {
     const elements = [];
     for (const key in this.state.sounds) {

--- a/patcher/src/widgets/Controller/components/PatchButton/index.tsx
+++ b/patcher/src/widgets/Controller/components/PatchButton/index.tsx
@@ -58,24 +58,24 @@ class PatchButton extends React.Component<PatchButtonProps, PatchButtonState> {
     }
     return (
       <div className='PatchButton'>
-        
+
         <div className='PatchButton__updateGroup'>
           <div>
             {this.renderButton()}
             <label>
               Updated {selectedServer.channelStatus !== ChannelStatus.NotInstalled && (selectedServer.lastUpdated &&
               selectedServer.lastUpdated > 0 ) ? moment(selectedServer.lastUpdated).fromNow() : 'never'}.
-            </label>          
+            </label>
           </div>
           {this.renderProgressText()}
         </div>
-        
+
         <Animate animationEnter='slideInUp' animationLeave='slideOutDown' durationEnter={400} durationLeave={500}>
-          
+
           {this.state.showEuala ? (<div className='fullscreen-blackout flex-row' key='accept-euala'>
                                       <EualaModal accept={this.launchClient} decline={this.closeEualaModal} />
                                     </div>) : null}
-        
+
         </Animate>
       </div>
     );
@@ -92,11 +92,15 @@ class PatchButton extends React.Component<PatchButtonProps, PatchButtonState> {
       }
     }
     this.installingChannel = -1;
-    this.startDownload = undefined;    
+    this.startDownload = undefined;
   }
 
   private playSound = (sound: string) => {
     events.fire('play-sound', sound);
+  }
+
+  private pauseMusic = (paused: boolean) => {
+    events.fire('pause-music', paused);
   }
 
   private playOffline = (evt: React.MouseEvent<HTMLDivElement>) => {
@@ -120,7 +124,7 @@ class PatchButton extends React.Component<PatchButtonProps, PatchButtonState> {
       this.commands = '';
     }
 
-    
+
     // Save selected channel, server, and character
     const lastPlay = {
       channelID: selectedServer.channelID as number,
@@ -186,23 +190,24 @@ class PatchButton extends React.Component<PatchButtonProps, PatchButtonState> {
     // const index = utils.findIndexWhere(channels, c => c.channelID === selectedServer.channelID);
 
     switch (selectedServer.channelStatus) {
-      
+
       case ChannelStatus.NotInstalled:
         return <div className='PatchButton__button' onClick={this.install}>Install</div>;
-      
+
       case ChannelStatus.Validating:
         this.startDownload = undefined;
         return <div className='PatchButton__button PatchButton__button--disabled'>Validating</div>;
-      
+
       case ChannelStatus.Updating:
 
         return <div className='PatchButton__button PatchButton__button--disabled'>Installing</div>;
-      
+
       case ChannelStatus.OutOfDate:
         return <div className='PatchButton__button PatchButton__button--disabled'>Awaiting Update</div>;
-      
+
       case ChannelStatus.Ready:
 
+        this.pauseMusic(false);
         for (let vid: any = 0; vid < videoElements.length; vid++) {
           videoElements[vid].play();
         }
@@ -226,29 +231,30 @@ class PatchButton extends React.Component<PatchButtonProps, PatchButtonState> {
             return <div className='PatchButton__button PatchButton__button--success' onClick={this.playNow}>Play Now</div>;
           }
         }
-        
+
         return <div className='PatchButton__button PatchButton__button--success' onClick={this.playNow}>Play Now</div>;
-      
+
       case ChannelStatus.Launching:
         return <div className='PatchButton__button PatchButton__button--disabled'>Launching</div>;
-      
+
       case ChannelStatus.Running:
+        this.pauseMusic(true);
         for (let vid: any = 0; vid < videoElements.length; vid++) {
           videoElements[vid].pause();
         }
         return <div className='PatchButton__button PatchButton__button--disabled'>Playing</div>;
-      
+
       case ChannelStatus.Uninstalling:
         this.startDownload = undefined;
         return <div className='PatchButton__button PatchButton__button--disabled'>Uninstalling</div>;
-      
+
       case ChannelStatus.UpdateFailed:
         return <div className='PatchButton__button PatchButton__button--error' onClick={this.install}>Update Failed.</div>;
     }
   }
 
   private renderProgressText = () => {
-    
+
     if (this.installingChannel === -1) return null;
 
     if (this.startDownload === undefined) this.startDownload = Date.now();

--- a/patcher/src/widgets/Controller/components/PatchButton/index.tsx
+++ b/patcher/src/widgets/Controller/components/PatchButton/index.tsx
@@ -181,6 +181,21 @@ class PatchButton extends React.Component<PatchButtonProps, PatchButtonState> {
     this.playSound('select');
   }
 
+  private shouldPauseMusic = () => {
+    const { servers } = this.props;
+    let running = false;
+    if (servers) {
+      for (const key in servers) {
+        const server = servers[key];
+        if (server.channelStatus === ChannelStatus.Running) {
+          running = true;
+        }
+      }
+    }
+    // music should be paused if there are any clients running
+    return running;
+  }
+
   private renderButton = () => {
     const { selectedServer } = this.props;
     const videoElements: any = document.getElementsByTagName('video');
@@ -207,7 +222,7 @@ class PatchButton extends React.Component<PatchButtonProps, PatchButtonState> {
 
       case ChannelStatus.Ready:
 
-        this.pauseMusic(false);
+        this.pauseMusic(this.shouldPauseMusic());
         for (let vid: any = 0; vid < videoElements.length; vid++) {
           videoElements[vid].play();
         }


### PR DESCRIPTION
This PR addresses the following issues:

1. Pause music while client is running
2. The background music is supposed to play in a loop and wasn't
3. Fades music in/out instead of abruptly pausing playing.

Notes:-

Added an ability to pause music playing by firing a pause-music event with true/false argument, which the sound component pickups up and sets paused state.  The existing logic that pauses/resumes video now also pauses/resumes music.

The background audio was not looping properly.  It would play once, then seeming randomly start playing again, in fact it would start playing again whenever a UI sound was triggered.

When sound is paused/resumed, it is now fades out/in which sounds better.  There is a quirk in that I wanted mute/unmute to be abrupt (not fade) and mute is abrupt but unmute isn't because I can't tell with the information available why sound is being unpaused, is it because state is unpausing or because props are unmuting.  Without knowing previous state, its impossible to tell.  I have left a comment about this in the code.