### PR TITLE
Fix attribute offsets

### DIFF
--- a/patcher/src/widgets/CharacterCreation/index.tsx
+++ b/patcher/src/widgets/CharacterCreation/index.tsx
@@ -408,7 +408,7 @@ class CharacterCreation extends React.Component<CharacterCreationProps, any> {
     this.props.dispatch(fetchRaces(this.props.apiHost, this.props.shard, this.props.apiVersion));
     this.props.dispatch(fetchPlayerClasses(this.props.apiHost, this.props.shard, this.props.apiVersion));
     this.props.dispatch(fetchAttributes(this.props.apiHost, this.props.shard, this.props.apiVersion));
-    this.props.dispatch(fetchAttributeOffsets(this.props.apiHost, this.props.shard, this.props.apiVersion));
+    this.props.dispatch(fetchAttributeOffsets(this.props.shard));
     this.setState({page: pages.FACTION_SELECT});
   }
 

--- a/patcher/src/widgets/CharacterCreation/index.tsx
+++ b/patcher/src/widgets/CharacterCreation/index.tsx
@@ -404,10 +404,10 @@ class CharacterCreation extends React.Component<CharacterCreationProps, any> {
     this.props.dispatch(resetAttributeOffsets());
     this.props.dispatch(resetAttributes());
     this.props.dispatch(resetCharacter());
-    this.props.dispatch(fetchFactions(this.props.apiHost, this.props.shard, this.props.apiVersion));
-    this.props.dispatch(fetchRaces(this.props.apiHost, this.props.shard, this.props.apiVersion));
+    this.props.dispatch(fetchFactions(this.props.shard));
+    this.props.dispatch(fetchRaces(this.props.shard));
     this.props.dispatch(fetchPlayerClasses(this.props.apiHost, this.props.shard, this.props.apiVersion));
-    this.props.dispatch(fetchAttributes(this.props.apiHost, this.props.shard, this.props.apiVersion));
+    this.props.dispatch(fetchAttributes(this.props.shard));
     this.props.dispatch(fetchAttributeOffsets(this.props.shard));
     this.setState({page: pages.FACTION_SELECT});
   }

--- a/patcher/src/widgets/CharacterCreation/services/session/attributeOffsets.ts
+++ b/patcher/src/widgets/CharacterCreation/services/session/attributeOffsets.ts
@@ -6,7 +6,7 @@
 
 import { Promise } from 'es6-promise';
 import 'isomorphic-fetch';
-import { Race, Gender } from 'camelot-unchained';
+import { Race, Gender, webAPI } from 'camelot-unchained';
 
 import { fetchJSON } from '../../lib/fetchHelpers';
 import ResponseError from '../../lib/ResponseError';
@@ -43,22 +43,22 @@ export function fetchAttributeOffsetsSuccess(offsets: AttributeOffsetInfo[]) {
   };
 }
 
-export function fetchAttributeOffsetsFailed(error: ResponseError) {
+export function fetchAttributeOffsetsFailed(error: any) {
   return {
     type: FETCH_ATTRIBUTE_OFFSETS_FAILED,
-    error: error.message,
+    error: error.Message,
   };
 }
 
-export function fetchAttributeOffsets(
-  apiUrl: string = 'https://api.camelotunchained.com/',
-  shard: number = 1,
-  apiVersion: number = 1) {
+export function fetchAttributeOffsets(shard: number = 1) {
   return (dispatch: (action: any) => any) => {
     dispatch(requestAttributeOffsets());
-    return fetchJSON(`${apiUrl}gamedata/attributeoffsets/${shard}?api-version=${apiVersion}`)
-      .then((offsets: AttributeOffsetInfo[]) => dispatch(fetchAttributeOffsetsSuccess(offsets)))
-      .catch((error: ResponseError) => dispatch(fetchAttributeOffsetsFailed(error)));
+    return webAPI.GameDataAPI.getAttributeOffsetsV1(shard)
+      .then((value: any) => {
+        dispatch(value.ok
+                  ? fetchAttributeOffsetsSuccess(value.data)
+                  : fetchAttributeOffsetsFailed(value.error));
+      });
   };
 }
 

--- a/patcher/src/widgets/CharacterCreation/services/session/factions.ts
+++ b/patcher/src/widgets/CharacterCreation/services/session/factions.ts
@@ -9,6 +9,7 @@ import 'isomorphic-fetch';
 
 import { fetchJSON } from '../../lib/fetchHelpers';
 import ResponseError from '../../lib/ResponseError';
+import { webAPI } from 'camelot-unchained';
 
 export interface FactionInfo {
   id: number;
@@ -57,15 +58,13 @@ export function selectFaction(selected: FactionInfo) {
   };
 }
 
-export function fetchFactions(
-  apiUrl: string = 'https://api.camelotunchained.com/',
-  shard: number = 1,
-  apiVersion: number = 1) {
+export function fetchFactions(shard: number = 1) {
   return (dispatch: (action: any) => any) => {
     dispatch(requestFactions());
-    return fetchJSON(`${apiUrl}gamedata/factions?api-version=${apiVersion}`)
-      .then((factions: FactionInfo[]) => dispatch(fetchFactionsSuccess(factions)))
-      .catch((error: ResponseError) => dispatch(fetchFactionsFailed(error)));
+    return webAPI.GameDataAPI.getFactionInfoV1()
+      .then((value: any) => {
+        dispatch(value.ok ? fetchFactionsSuccess(value.data) : fetchFactionsFailed(value.error));
+      });
   };
 }
 

--- a/patcher/src/widgets/CharacterCreation/services/session/races.ts
+++ b/patcher/src/widgets/CharacterCreation/services/session/races.ts
@@ -6,7 +6,7 @@
 
 import { Promise } from 'es6-promise';
 import 'isomorphic-fetch';
-import { Race, Faction } from 'camelot-unchained';
+import { Race, Faction, webAPI } from 'camelot-unchained';
 
 import { fetchJSON } from '../../lib/fetchHelpers';
 import ResponseError from '../../lib/ResponseError';
@@ -40,10 +40,10 @@ export function fetchRacesSuccess(races: RaceInfo[]) {
   };
 }
 
-export function fetchRacesFailed(error: ResponseError) {
+export function fetchRacesFailed(error: any) {
   return {
     type: FETCH_RACES_FAILED,
-    error: error.message,
+    error: error.Message,
   };
 }
 
@@ -61,12 +61,13 @@ export function resetRace() {
 }
 
 
-export function fetchRaces(apiUrl: string = 'https://api.camelotunchained.com/', shard: number = 1, apiVersion: number = 1) {
+export function fetchRaces(shard: number = 1) {
   return (dispatch: (action: any) => any) => {
     dispatch(requestRaces());
-    return fetchJSON(`${apiUrl}gamedata/races?api-version=${apiVersion}`)
-      .then((races: RaceInfo[]) => dispatch(fetchRacesSuccess(races)))
-      .catch((error: ResponseError) => dispatch(fetchRacesFailed(error)));
+    return webAPI.GameDataAPI.getRacesV1()
+      .then((value: any) => {
+        dispatch(value.ok ? fetchRacesSuccess(value.data) : fetchRacesFailed(value.error));
+      });
   };
 }
 


### PR DESCRIPTION
Switch to use ``webAPI.GameDataAPI.getAttributeOffsetsV1`` to fetch attribute offsets.

Notes:

``apiHost`` and ``apiVersion`` parameters were dropped with apiHost being determined by ``GameDataAPI`` and version determined by function name (ie hard coded).  Hope this is ok.

Also, the typings on GameDataAPI calls are a bit naff, to the point that because of ts-lint was forced to add :any to the value param to stop lint complaining.  Would be nice to have a named type definition for these generated APIs that we can use for the value type.

Also, I can expand this PR by converting some of the other APIs to use ``GameDataAPI`` if you want (or submit them as separate PRs).