### PR TITLE
Update @types/react-addons-transition-group version

### DIFF
--- a/patcher/package.json
+++ b/patcher/package.json
@@ -56,7 +56,7 @@
     "@types/lodash": "^4.14.61",
     "@types/react": "^15.0.14",
     "@types/react-addons-css-transition-group": "^15.0.1",
-    "@types/react-addons-transition-group": "^0.14.19",
+    "@types/react-addons-transition-group": "^15.0.0",
     "@types/react-dom": "^0.14.23",
     "@types/redux-thunk": "^2.1.0",
     "babel-cli": "^6.5.1",


### PR DESCRIPTION
This was causing errors in the TravisCI build.