### PR TITLE
update travis config, postinstall scripts and lint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: node_js
 node_js:
- - "6"
-sudo: required 
+ - "7"
 before_install:
- - "cd game"
+ - "cd $TRAVIS_BUILD_DIR/game/hud && npm install"
+ - "cd $TRAVIS_BUILD_DIR/library && npm install"
+ - "cd $TRAVIS_BUILD_DIR/patcher && npm install"
 script:
- - "cd hud && npm install && npm start build && cd ../../library && npm install && npm start build && cd ../patcher && npm install && npm start build"
- - "cd ../game/hud && npm start test"
- - "cd ../../library && npm start test"
+ - "cd $TRAVIS_BUILD_DIR/game/hud && npm start build && npm start test"
+ - "cd $TRAVIS_BUILD_DIR/library && npm start build && npm start test"
+ - "cd $TRAVIS_BUILD_DIR/patcher && npm start build"

--- a/game/hud/package.json
+++ b/game/hud/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "start": "nps",
-    "postinstall": "rimraf typings && typings install"
+    "postinstall": "cwd-in-node-modules || rimraf typings && typings install"
   },
   "dependencies": {
     "aphrodite": "^1.1.0",
@@ -92,7 +92,8 @@
     "redux-typed-modules": "^2.2.1",
     "sass-importer-node": "^1.0.1",
     "whatwg-fetch": "^2.0.2",
-    "yargs-parser": "^2.4.1"
+    "yargs-parser": "^2.4.1",
+    "cwd-in-node-modules": "^1.0.1"
   },
   "devDependencies": {
     "@types/aphrodite": "^0.5.5",

--- a/game/kos/package.json
+++ b/game/kos/package.json
@@ -28,7 +28,7 @@
     "name": "kos"
   },
   "scripts": {
-    "postinstall": "npm run typings",
+    "postinstall": "cwd-in-node-modules || npm run typings",
     "typings": "npm run clean:typings && typings install",
     "clean:typings": "rimraf typings",
     "clean:tmp": "rimraf tmp",
@@ -66,7 +66,8 @@
   "dependencies": {
     "camelot-unchained": "latest",
     "react": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "react-dom": "^0.14.3",
+    "cwd-in-node-modules": "^1.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/game/perfhud/package.json
+++ b/game/perfhud/package.json
@@ -30,7 +30,7 @@
     "name": "perfhud"
   },
   "scripts": {
-    "postinstall": "npm run typings",
+    "postinstall": "cwd-in-node-modules || npm run typings",
     "typings": "npm run clean:typings && typings install",
     "clean:typings": "rimraf typings",
     "clean:tmp": "rimraf tmp",
@@ -68,7 +68,8 @@
   "dependencies": {
     "camelot-unchained": "latest",
     "react": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "react-dom": "^0.14.3",
+    "cwd-in-node-modules": "^1.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/library/package.json
+++ b/library/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "start": "nps",
-    "postinstall": "rimraf typings && typings install"
+    "postinstall": "cwd-in-node-modules || rimraf typings && typings install"
   },
   "dependencies": {
     "aphrodite": "^1.1.0",
@@ -65,7 +65,8 @@
     "react": "^15.4.2",
     "react-addons-css-transition-group": "^0.14.6",
     "react-dom": "^15.4.2",
-    "redux-typed-modules": "^2.2.1"
+    "redux-typed-modules": "^2.2.1",
+    "cwd-in-node-modules": "^1.0.1"
   },
   "devDependencies": {
     "@types/aphrodite": "^0.5.5",

--- a/library/src/components/GridView.tsx
+++ b/library/src/components/GridView.tsx
@@ -219,7 +219,7 @@ export class GridViewImpl<P extends GridViewProps, S extends GridViewState> exte
     } as S);
   }
 
-  public componentWillReceiveProps (nextProps: P) {
+  public componentWillReceiveProps(nextProps: P) {
     const items = cloneDeep(nextProps.items);
     this.setState({
       items,

--- a/widgets/cu-character-creation/package.json
+++ b/widgets/cu-character-creation/package.json
@@ -19,7 +19,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "postinstall": "rimraf typings && typings install",
+    "postinstall": "cwd-in-node-modules || rimraf typings && typings install",
     "clean": "rimraf tmp && rimraf lib",
     "babel": "babel tmp -d lib",
     "sass": "node-sass src/ -o lib/ --importer node_modules/camelot-unchained/lib/third-party/sass-importer/sass-npm-importer.js",
@@ -41,7 +41,8 @@
     "react-dom": "^0.14.7",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
-    "redux-thunk": "^2.1.0"
+    "redux-thunk": "^2.1.0",
+    "cwd-in-node-modules": "^1.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/widgets/cu-xmpp-chat/package.json
+++ b/widgets/cu-xmpp-chat/package.json
@@ -19,7 +19,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "postinstall": "rimraf typings && typings install",
+    "postinstall": "cwd-in-node-modules || rimraf typings && typings install",
     "clean": "rimraf tmp && rimraf lib",
     "babel": "babel tmp -d lib",
     "sass": "node-sass src/ -o lib/ --importer node_modules/camelot-unchained/lib/third-party/sass-importer/sass-npm-importer.js",
@@ -43,7 +43,8 @@
     "react-dom": "^0.14.7",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
-    "redux-thunk": "^2.1.0"
+    "redux-thunk": "^2.1.0",
+    "cwd-in-node-modules": "^1.0.1"
   },
   "devDependencies": {
     "@types/aphrodite": "^0.5.5",


### PR DESCRIPTION
Changes:

### update travis config

- node version is now set to `7` instead of `6`.
- `npm install` commands have separated and moved to the `before_install` section
- builds and tests have been organized to separate lines
- made use of `$TRAVIS_BUILD_DIR` environment variable to simplify `cd` calls.

These changes result in a much nicer and more meaningful output from travis. e.g. https://travis-ci.org/CUModSquad/Camelot-Unchained/builds/236572039

###  fixes lint errors

There was a lint issue introduced in https://github.com/CUModSquad/Camelot-Unchained/commit/9142e7759e561cca51fa7c417e2d8b4fbb790bdc which is now fixed.

### updates postinstall scripts

The existing `postinstall` scripts are run even when the modules are installed into the `node_modules` directory e.g. `rimraf typings && typings install` will run on `node_modules/camelot-unchained` whilst running `npm install` in `game/hud`.

This is one of the key things preventing `yarn` from being used, as it handles `bin` paths slightly different to `npm`. It will also prevent any of the libraries/modules from being installed where `rimraf` or `typings` do not exist e.g. in a standalone project that does not use typescript.

The new postinstall looks like `cwd-in-node-modules || rimraf typings && typings install` which will only run `rimraf typings && typings install` if the `cwd` is not inside a `node_modules` directory