### PR TITLE
update cu-xmpp-chat to use latest library

### DIFF
--- a/widgets/cu-xmpp-chat/package.json
+++ b/widgets/cu-xmpp-chat/package.json
@@ -31,7 +31,7 @@
     "postbuild": "rimraf tmp"
   },
   "dependencies": {
-    "camelot-unchained": "^0.5.0",
+    "camelot-unchained": "^0.8.13",
     "es6-promise": "^3.1.2",
     "isomorphic-fetch": "^2.2.1",
     "node-xmpp-client": "^2.1.0",

--- a/widgets/cu-xmpp-chat/src/components/JoinRoomList.tsx
+++ b/widgets/cu-xmpp-chat/src/components/JoinRoomList.tsx
@@ -25,11 +25,11 @@ class JoinRoomList extends React.Component<JoinRoomListProps, JoinRoomListState>
     super(props);
   }
 
-  componentDidMount = () : void => {
+  public componentDidMount() : void {
     document.addEventListener("mousedown", this.onmousedown, true);
   }
 
-  componentWillUnmount = () : void => {
+  public componentWillUnmount() : void {
     document.removeEventListener("mousedown", this.onmousedown, true);
   }
 


### PR DESCRIPTION
The `cu-xmpp-chat` library was using an old version of `camelot-unchained` this updates the version to latest and fixes minor upgrade issues for tsc build.

If these changes are ok, would it also be possible to get `cu-xmpp-chat` published to the registry.