### PR TITLE
fix scripts and devDependencies

### DIFF
--- a/game/hud/package.json
+++ b/game/hud/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "start": "nps",
-    "postinstall": "cwd-in-node-modules || rimraf typings && typings install"
+    "postinstall": "rimraf typings && typings install"
   },
   "dependencies": {
     "aphrodite": "^1.1.0",
@@ -126,6 +126,7 @@
     "node-sass": "^3.8.0",
     "p-s": "^3.1.0",
     "react-test-renderer": "^15.5.4",
+    "rimraf": "^2.6.1",
     "ts-jest": "^19.0.14",
     "tslint": "^5.0.0",
     "tslint-config-airbnb": "^1.1.1",

--- a/library/package.json
+++ b/library/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "start": "nps",
-    "postinstall": "cwd-in-node-modules || rimraf typings && typings install"
+    "postinstall": "cwd-in-node-modules || (rimraf typings && typings install)"
   },
   "dependencies": {
     "aphrodite": "^1.1.0",
@@ -85,6 +85,7 @@
     "npm-watch": "^0.1.4",
     "nps": "^5.0.5",
     "react-test-renderer": "^15.5.4",
+    "rimraf": "^2.6.1",
     "ts-jest": "^19.0.14",
     "tslint": "^5.0.0",
     "tslint-config-airbnb": "^1.1.1",

--- a/widgets/cu-character-creation/package.json
+++ b/widgets/cu-character-creation/package.json
@@ -19,7 +19,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "postinstall": "cwd-in-node-modules || rimraf typings && typings install",
+    "postinstall": "cwd-in-node-modules || (rimraf typings && typings install)",
     "clean": "rimraf tmp && rimraf lib",
     "babel": "babel tmp -d lib",
     "sass": "node-sass src/ -o lib/ --importer node_modules/camelot-unchained/lib/third-party/sass-importer/sass-npm-importer.js",
@@ -52,6 +52,7 @@
     "http-server": "^0.9.0",
     "mkdirp": "^0.5.1",
     "node-sass": "^3.4.2",
+    "rimraf": "^2.6.1",
     "typescript": "^1.8.10",
     "typings": "^1.3.2"
   }

--- a/widgets/cu-xmpp-chat/package.json
+++ b/widgets/cu-xmpp-chat/package.json
@@ -19,7 +19,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "postinstall": "cwd-in-node-modules || rimraf typings && typings install",
+    "postinstall": "cwd-in-node-modules || (rimraf typings && typings install)",
     "clean": "rimraf tmp && rimraf lib",
     "babel": "babel tmp -d lib",
     "sass": "node-sass src/ -o lib/ --importer node_modules/camelot-unchained/lib/third-party/sass-importer/sass-npm-importer.js",
@@ -59,6 +59,7 @@
     "http-server": "^0.9.0",
     "mkdirp": "^0.5.1",
     "node-sass": "^3.8.0",
+    "rimraf": "^2.6.1",
     "typescript": "^2.1.6",
     "typings": "^1.3.2"
   }


### PR DESCRIPTION
I have been attempting to get `yarn` to work on travis and have identified a couple of issues:

1. we need `rimraf` installed as a devDependency for the projects which need it.
2. the previous postinstall script I added `cwd-in-node-modules || rimraf typings && typings install` is incorrect and should actually be `cwd-in-node-modules || (rimraf typings && typings install)` .

These are happening because travis is running on a non windows setup, and `sh` is interpreting the scripts slightly different.

If these changes are ok, would it be possible to publish:

- `camelot-unchained`
- `cu-xmpp-chat`

(sorry for all the re-publishing)