### PR TITLE
Making graphql optional here

### DIFF
--- a/library/src/graphql/react.tsx
+++ b/library/src/graphql/react.tsx
@@ -85,7 +85,7 @@ export interface GraphQLProps<T> extends GraphQLData<T> {
 }
 
 export interface GraphQLInjectedProps<T> {
-  graphql: GraphQLProps<T>;
+  graphql?: GraphQLProps<T>;
 }
 
 export function useConfig(config: Partial<GraphQLConfig>) {


### PR DESCRIPTION
I think it should be optional. Otherwise it would be missing, when you are calling InventoryBody in Inventory.tsx, line 94-98.
