### PR TITLE
upgrade library for game/hud & temp fix for graphql issue

### DIFF
--- a/game/hud/src/widgets/Social/components/PersonalContent.tsx
+++ b/game/hud/src/widgets/Social/components/PersonalContent.tsx
@@ -10,7 +10,7 @@
  */
 
 import * as React from 'react';
-import { ql } from 'camelot-unchained';
+import { CUCharacter } from 'camelot-unchained/lib/graphql/fragments/CUCharacter';
 import { LinkAddress } from '../services/session/nav/navTypes';
 
 import InvitesList from './InvitesList';
@@ -19,7 +19,7 @@ export interface PersonalContentProps {
   dispatch: (action: any) => any;
   address: LinkAddress;
   refetch: () => void;
-  myCharacter: ql.CUCharacter;
+  myCharacter: CUCharacter;
 }
 
 /* tslint:disable */

--- a/game/hud/yarn.lock
+++ b/game/hud/yarn.lock
@@ -1271,8 +1271,8 @@ camelot-unchained@^0.8.13:
     redux-typed-modules "^2.2.1"
 
 camelot-unchained@^0.9.7:
-  version "0.9.8"
-  resolved "http://registry.camelotunchained.com/camelot-unchained/-/camelot-unchained-0.9.8.tgz#46751382bb6a02c79dfbd6f4e200c037a664dfef"
+  version "0.9.13"
+  resolved "http://registry.camelotunchained.com/camelot-unchained/-/camelot-unchained-0.9.13.tgz#84ca30b7ae32231c0f6e323997c2e65ef0d49572"
   dependencies:
     aphrodite "^1.2.3"
     cwd-in-node-modules "^1.0.1"


### PR DESCRIPTION
This upgrades `camelot-unchained` to latest version for `game/hud`.

It also adds a small fix to prevent social component using new schema.ts graphql interfaces, as it still needs to be refactored to use new graphql system.