### PR TITLE
initial graphql cache

### DIFF
--- a/game/hud/tsconfig.json
+++ b/game/hud/tsconfig.json
@@ -16,7 +16,8 @@
     "experimentalDecorators": true,
     "plugins": [
       { "name": "tslint-language-service"}
-    ]
+    ],
+    "allowSyntheticDefaultImports": true
   },
   "compileOnSave": false,
   "buildOnSave": false,

--- a/library/package.json
+++ b/library/package.json
@@ -54,6 +54,8 @@
     "postinstall": "cwd-in-node-modules || (rimraf typings && typings install && nps gql && nps definitions)"
   },
   "dependencies": {
+    "@types/lru-cache": "^4.1.0",
+    "@types/object-hash": "^0.5.29",
     "aphrodite": "^1.2.3",
     "cwd-in-node-modules": "^1.0.1",
     "es6-promise": "^3.0.2",
@@ -62,7 +64,9 @@
     "isomorphic-fetch": "^2.2.1",
     "jquery": "^3.0.0",
     "lodash": "^4.17.4",
+    "lru-cache": "^4.1.1",
     "moment": "^2.17.1",
+    "object-hash": "^1.1.8",
     "react": "^15.6.1",
     "react-addons-css-transition-group": "^0.14.6",
     "react-dom": "^15.6.1",

--- a/library/src/graphql/cache.ts
+++ b/library/src/graphql/cache.ts
@@ -1,0 +1,251 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import * as LRU from 'lru-cache';
+import * as hash from 'object-hash';
+
+export interface CacheOptions {
+  maxAge: number;
+}
+
+export interface CacheAdapter {
+  getItem(key: string, options: Partial<CacheOptions>): Promise<null|string>;
+  setItem(key: string, data: string, options: Partial<CacheOptions>): Promise<boolean>;
+  removeItem(key: string, options: Partial<CacheOptions>): Promise<boolean>;
+}
+
+const IN_MEMORY_SIZE: number = 1024 * 1024 * 0.5; // 0.5MB
+const LOCAL_STORAGE_SIZE: number = 1024 * 1024 * 5; // 5MB
+const DEFAULT_MAX_AGE: number = 1000 * 30; // 30 seconds in ms
+const DEBUG: boolean = false; // turn logging on/off
+
+class InMemoryCacheAdapter implements CacheAdapter {
+
+  public lru: LRU.Cache<string, string>;
+  public maxAge: number;
+
+  public constructor(maxAge: number = DEFAULT_MAX_AGE) {
+    this.maxAge = maxAge;
+    this.lru = new LRU({
+      max: IN_MEMORY_SIZE, // 0.5MB
+      maxAge, // ms
+      length: (value: string) => {
+        return value.length;
+      },
+    });
+  }
+
+  public getItem = async (key: string, options: Partial<CacheOptions> = {}): Promise<null|string> => {
+    DEBUG && console.log('InMemoryCacheAdapter getItem', key);
+    if (this.lru.has(key)) {
+      return this.lru.get(key);
+    } else {
+      return null;
+    }
+  }
+
+  public setItem = async (key: string, data: string, options: Partial<CacheOptions> = {}): Promise<boolean> => {
+    const maxAge = options.maxAge ? options.maxAge : this.maxAge;
+    DEBUG && console.log('InMemoryCacheAdapter setItem', key, maxAge);
+    return this.lru.set(key, data, maxAge);
+  }
+
+  public removeItem = async (key: string, options: Partial<CacheOptions> = {}): Promise<boolean> => {
+    this.lru.del(key);
+    DEBUG && console.log('InMemoryCacheAdapter removeItem', key);
+    return true;
+  }
+
+}
+
+class LocalStorageCacheAdapter implements CacheAdapter {
+  
+    public lru: LRU.Cache<string, number>;
+    public maxAge: number;
+  
+    public constructor(maxAge: number = DEFAULT_MAX_AGE) {
+      this.maxAge = maxAge;
+      this.lru = new LRU({
+        max: LOCAL_STORAGE_SIZE, // 5MB
+        maxAge, // ms
+        length: (value: number) => {
+          return value;
+        },
+        dispose: (key: string, value: number) => {
+          try {
+            localStorage.removeItem(this.getKeyName(key));
+          } catch (e) {
+            console.error(e);
+          }
+        },
+      });
+      this.populateKeys();
+    }
+  
+    public getItem = async (key: string, options: Partial<CacheOptions> = {}): Promise<null|string> => {
+      DEBUG && console.log('LocalStorageCacheAdapter getItem', key);
+      if (this.lru.has(key) && this.lru.get(key)) {
+        try {
+          return localStorage.getItem(this.getKeyName(key));
+        } catch (e) {
+          console.error(e);
+          await this.removeItem(key);
+          return null;
+        }
+      } else {
+        return null;
+      }
+    }
+  
+    public setItem = async (key: string, data: string, options: Partial<CacheOptions> = {}): Promise<boolean> => {
+      const maxAge = options.maxAge ? options.maxAge : this.maxAge;
+      DEBUG && console.log('LocalStorageCacheAdapter setItem', key, maxAge);
+      let response = this.lru.set(key, data.length, maxAge);
+      if (response) {
+        try {
+          localStorage.setItem(this.getKeyName(key), data);
+          this.storeKey(key, data.length, maxAge);
+        } catch (e) {
+          console.error(e);
+          await this.removeItem(key);
+          response = false;
+        }
+      }
+      return response;
+    }
+  
+    public removeItem = async (key: string, options: Partial<CacheOptions> = {}): Promise<boolean> => {
+      this.lru.del(key);
+      DEBUG && console.log('LocalStorageCacheAdapter removeItem', key);
+      return true;
+    }
+
+    public getKeyName = (key: string) => {
+      return `GRAPHQL_CACHE_${key}`;
+    }
+
+    public populateKeys = () => {
+      const keys = this.getKeys();
+      const now = (new Date()).getTime();
+      DEBUG && console.log('LocalStorageCacheAdapter populateKeys', keys, now);
+      const newKeys = [];
+      keys.forEach((key) => {
+        if (key.expires > now) {
+          DEBUG && console.log('LocalStorageCacheAdapter populateKey', key);
+          this.lru.set(key.key, key.size, key.expires - now);
+          newKeys.push(key);
+        }
+      });
+      localStorage.setItem('GRAPHQL_CACHE_KEYS', JSON.stringify(newKeys));
+    }
+    
+    public storeKey = (key: string, size: number, maxAge: number) => {
+      let keys = this.getKeys();
+      keys = keys.filter(k => k.key !== key);
+      keys.push({
+        key,
+        size,
+        expires: (new Date()).getTime() + maxAge,
+      });
+      localStorage.setItem('GRAPHQL_CACHE_KEYS', JSON.stringify(keys));
+    }
+
+    public getKeys = (): {key: string, size: number, expires: number}[] => {
+      let keys: {key: string, size: number, expires: number}[] = [];
+      const rawKeys = localStorage.getItem('GRAPHQL_CACHE_KEYS');
+      if (rawKeys) {
+        keys = JSON.parse(rawKeys);
+        if (!Array.isArray(keys)) {
+          keys = [];
+        }
+      }
+      return keys;
+    }
+}
+
+export interface CacheResult {
+  key: string;
+  isHit: boolean;
+  data?: any;
+}
+
+export class Cache {
+
+  private adapters: CacheAdapter[];
+  
+  public getItem = async (rawKey: string, options: Partial<CacheOptions> = {}): Promise<CacheResult> => {
+    const key = hash.sha1(rawKey);
+
+    const adapters = this.getAdapters();
+
+    const result: CacheResult = {
+      key,
+      isHit: false,
+    };
+
+    for (let i = 0; i < adapters.length; i++) {
+      const adapterResult = await adapters[i].getItem(key, options);
+      if (adapterResult != null) {
+        result.isHit = true;
+        result.data = JSON.parse(adapterResult);
+        break;
+      }
+    }
+
+    DEBUG && console.log('Cache getItem', key, result);
+
+    return result;
+  }
+  
+  public setItem = async (rawKey: string, rawData: any, options: Partial<CacheOptions> = {}): Promise<boolean[]> => {
+    const key = hash.sha1(rawKey);
+    const data = JSON.stringify(rawData);
+
+    const promises = this.getAdapters().map(adapter => adapter.setItem(key, data, options));
+
+    let response = [];
+
+    try {
+      response = await Promise.all(promises);
+    } catch (e) {
+      console.error(e);
+    }
+    
+    DEBUG && console.log('Cache setItem', key, data.length, response);
+    return response;
+  }
+  
+  public removeItem = async (rawKey: string, options: Partial<CacheOptions> = {}): Promise<boolean[]> => {
+    const key = hash.sha1(rawKey);
+
+    const promises = this.getAdapters().map(adapter => adapter.removeItem(key, options));
+
+    let response = [];
+
+    try {
+      response = await Promise.all(promises);
+    } catch (e) {
+      console.error(e);
+    }
+    
+    DEBUG && console.log('Cache removeItem', key, response);
+    return response;
+  }
+
+  protected getAdapters(): CacheAdapter[] {
+    if (!this.adapters) {
+      this.adapters = [
+        new InMemoryCacheAdapter(),
+        new LocalStorageCacheAdapter(),
+      ];
+    }
+    return this.adapters;
+  }
+}
+
+const cacheInstance = new Cache();
+
+export default cacheInstance;

--- a/library/src/graphql/react.tsx
+++ b/library/src/graphql/react.tsx
@@ -124,6 +124,8 @@ export function withGraphQL<
           url: this.opts.url,
           requestOptions: this.opts.requestOptions,
           stringifyVariables: this.opts.stringifyVariables,
+          useCache: this.opts.useCache,
+          setToCache: this.opts.setToCache,
         });
       }
 

--- a/library/tsconfig.json
+++ b/library/tsconfig.json
@@ -12,7 +12,8 @@
     "lib": [
       "esnext",
       "dom"
-    ]
+    ],
+    "allowSyntheticDefaultImports": true
   },
   "compileOnSave": false,
   "buildOnSave": false,

--- a/library/yarn.lock
+++ b/library/yarn.lock
@@ -20,6 +20,14 @@
   version "4.14.56"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.56.tgz#e7ed952ca250c5bdfbf6e75598c137785c41170e"
 
+"@types/lru-cache@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-4.1.0.tgz#ef69ce9c3ebb46bd146f0d80f0c1ce38b0508eae"
+
+"@types/object-hash@^0.5.29":
+  version "0.5.29"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-0.5.29.tgz#fe913ebb000bb7e72a5cb6bafbefb09552d49872"
+
 "@types/react-dom@^15.5.4":
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-15.5.4.tgz#3f75ba86a2ce9a7d1d9e7d1ee3f186f3a9652d8f"
@@ -3470,7 +3478,7 @@ lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "http://registry.camelotunchained.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
-lru-cache@^4.0.1:
+lru-cache@^4.0.1, lru-cache@^4.1.1:
   version "4.1.1"
   resolved "http://registry.camelotunchained.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
   dependencies:
@@ -3869,6 +3877,10 @@ object-assign@^3.0.0:
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "http://registry.camelotunchained.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-hash@^1.1.8:
+  version "1.1.8"
+  resolved "http://registry.camelotunchained.com/object-hash/-/object-hash-1.1.8.tgz#28a659cf987d96a4dabe7860289f3b5326c4a03c"
 
 object.omit@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This is the first draft for graphql cache.

You can enable some logging by setting `DEBUG` to true in `cache.ts`

It uses a chained adapter setup, so you could effectively have multiple cache systems working together with different restrictions. The new records will attempt to be set to all cache adapters.

Currently I have created the following adapters:
- In Memory
- Local Storage

The current setup has the in memory adapter with a 0.5 MB memory limit and the local storage adapter with 5 MB limit.

Would be great to get some feedback on this.