### PR TITLE
Improve sorting in GridView

### DIFF
--- a/library/src/components/GridView.tsx
+++ b/library/src/components/GridView.tsx
@@ -224,10 +224,11 @@ export class GridViewImpl<P extends GridViewProps, S extends GridViewState> exte
 
   public componentWillReceiveProps(nextProps: P) {
     const items = cloneDeep(nextProps.items);
+    const sortedItems = this.sortItems(items, this.props.columnDefinitions[this.state.currentSort.index], this.state.currentSort.sorted);
     this.setState({
       items,
       itemsPerPage: this.props.itemsPerPage || 25,
-      sortedItems: items,
+      sortedItems,
     } as S);
   }
 

--- a/library/src/components/GridView.tsx
+++ b/library/src/components/GridView.tsx
@@ -181,11 +181,11 @@ export class GridViewImpl<P extends GridViewProps, S extends GridViewState> exte
 
   public sortItems = (input: any[], column: ColumnDefinition, sorted: GridViewSort) => {
     if (sorted === GridViewSort.None) return input;
-    if (column.sortFunction) {
-      return input.sort((a, b) => sorted === GridViewSort.Down ?
-        column.sortFunction(a, b) : (column.sortFunction(a, b) * -1));
+    if (!column.sortFunction) {
+      column.sortFunction = (a: any, b: any) => column.key(a) < column.key(b) ? 1 : -1;
     }
-    return sorted === GridViewSort.Down ? input.sort() : input.sort().reverse();
+    return input.sort((a, b) => sorted === GridViewSort.Down ?
+      column.sortFunction(a, b) : (column.sortFunction(a, b) * -1));
   }
 
   public setSort = (index: number, sortBy: GridViewSort) => {


### PR DESCRIPTION
Currently you have to define a search function for each column of a grid. There are several reasons for it.

1. You need to tell the sort function, which column you want to use for sorting
2. You have to be careful, if you are sorting numbers. Standard behaviour is to turn numbers into strings, if no sort function is available for .sort, which means a wrong order
3. You need to do something special, like sorting this column using another column.

There is a solution for 1 and 2. If you use the function in the key of the columnDefinition on a row of data, it returns the value of the column for this row. This is either a string or a number. They are compared directly with each other with "<".  This comparison is working correctly for strings and numbers.

In most cases the key-function returns the value you want to use for sorting and you don't have to do something special (you need to do something special for dates for example). In those cases you no longer have to provide a custom search function via the columnDefinition. 

For new grids this means you have to write a lot less custom sort functions. 

For old grids this means a have to change nothing because the custom search function is used, if there is one. Of course you can do a clean up and delete most of the sort functions as they are no longer needed to get rid of several lines of code.  