### PR TITLE
Support VSC .code-workspace - multi-root workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ dev.config
 game/hud/gql/
 game/hud/src/gqlDocuments\.ts
 game/hud/src/gqlInterfaces\.ts
+**/*.code-workspace

--- a/Camelot Unchained.code-workspace
+++ b/Camelot Unchained.code-workspace
@@ -1,0 +1,14 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "library"
+		},
+		{
+			"path": "game\\hud"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
This PR ignores **/*.code-workspace except for one shared workspace called Camelot Unchained.

Custom workspaces can be created and called anything you like, for example, my.code-workspace that has your own preferred set of root folders.

Descendent folders can be root folders, so it's great for pulling out the thing you are currently working on making it quick to find.

![image](https://user-images.githubusercontent.com/99895/33684803-73ad4edc-dac7-11e7-9ec4-7a52cc9d6e19.png)

For more information see: https://code.visualstudio.com/docs/editor/multi-root-workspaces