### PR TITLE
bugfix: properly deactivate the material selector 

### DIFF
--- a/game/hud/src/widgets/Building/widgets/BuildPanel/components/BuildPanel/index.tsx
+++ b/game/hud/src/widgets/Building/widgets/BuildPanel/components/BuildPanel/index.tsx
@@ -67,7 +67,7 @@ class BuildPanel extends React.Component<BuildPanelProps, BuildPanelState> {
   }
 
   private materialSelectorDeactivated = () => {
-    this.setState((state, props) => ({ showMaterialSelector: true } as BuildPanelState));
+    this.setState((state, props) => ({ showMaterialSelector: false } as BuildPanelState));
   }
 }
 


### PR DESCRIPTION
the function materialSelectorDeactivated is called each time the material selector should hide. Because of that showMaterialSelector has to bet set to false.