### PR TITLE
Sound & FX icon position

### DIFF
--- a/patcher/src/components/WindowHeader/index.scss
+++ b/patcher/src/components/WindowHeader/index.scss
@@ -7,10 +7,9 @@
 .WindowHeader {
   position: fixed;
   top: 0;
-  left: 0;
-  right: 0;
+  right: 40px;
   height: 20px;
-  z-index: 100;
+  z-index: 110;
   display: flex;
   flex-direction: row-reverse;
   background-color: rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
Changed the position of the sound and fx icons, so that they are visible everywhere on the patcher (e.g. character creation).