### PR TITLE
Allow builds to continue on win 8.1 as well

### DIFF
--- a/game/hud/package-scripts.js
+++ b/game/hud/package-scripts.js
@@ -19,7 +19,7 @@ module.exports = {
       schema: 'apollo-codegen introspect-schema https://hatcheryapi.camelotunchained.com/graphql --output gql/schema.json',
       codegen: 'apollo-codegen generate src/**/*.graphql --schema gql/schema.json --target typescript --output src/gqlInterfaces.ts',
       collectAndConcat: 'graphql-document-collector "src/**/*.graphql" > gql/gqlDocument.json && concat-cli -f src/gqlPrepend.txt -f gql/gqlDocument.json -o src/gqlDocuments.ts',
-      default: '(nps gql.mkdir && nps gql.schema && nps gql.codegen && nps gql.collectAndConcat) || true'
+      default: '(nps gql.mkdir && nps gql.schema && nps gql.codegen && nps gql.collectAndConcat) || echo continuing...'
     },
     gqlLocal: {
       schema: 'apollo-codegen introspect-schema http://localhost:1337/graphql --output gql/schema.json',


### PR DESCRIPTION
Fixes an issue that causes the build to fail whenever the hatchery api server is down on windows 8.1

|| true doesn't work on win 8.1
|| echo continue... does though, and should work on win10 also