### PR TITLE
Fix a bunch of lint errors

### DIFF
--- a/game/hud/src/components/InteractiveAlert/ProgressionAlert.tsx
+++ b/game/hud/src/components/InteractiveAlert/ProgressionAlert.tsx
@@ -13,12 +13,12 @@ import { ProgressionAlert, IInteractiveAlert } from '@csegames/camelot-unchained
 
 // Utility Functions
 export function removeProgressionAlert(alertsList: IInteractiveAlert[], toRemove: ProgressionAlert) {
-  const alerts = filter([...alertsList], a => {
+  const alerts = filter([...alertsList], (a) => {
     return !(a.category === 'Progression' && (a as ProgressionAlert).when === toRemove.when);
   });
   return {
     alerts,
-  }
+  };
 }
 
 const Container = styled('div')`

--- a/game/hud/src/components/InteractiveAlert/TradeAlert.tsx
+++ b/game/hud/src/components/InteractiveAlert/TradeAlert.tsx
@@ -13,12 +13,12 @@ import { IInteractiveAlert, TradeAlert } from '@csegames/camelot-unchained/lib/g
 
 // Utility Functions
 export function removeTradeInvite(alertsList: IInteractiveAlert[], toRemove: TradeAlert) {
-  const alerts = _.filter([...alertsList], a => {
+  const alerts = _.filter([...alertsList], (a) => {
     return !(a.category === 'Trade' && (a as TradeAlert).otherName === toRemove.otherName);
   });
   return {
     alerts,
-  }
+  };
 }
 
 function openTradeWindow() {
@@ -105,7 +105,7 @@ export class TradeAlertView extends React.Component<TradeAlertProps> {
     this.props.remove(this.props.alert);
     this.makeAcceptRequest();
   }
-  
+
   private onDecline = () => {
     this.props.remove(this.props.alert);
     this.makeDeclineRequest();

--- a/game/hud/src/components/InteractiveAlert/index.tsx
+++ b/game/hud/src/components/InteractiveAlert/index.tsx
@@ -67,7 +67,7 @@ export class InteractiveAlertView extends React.Component<Props, State> {
                   return <GroupAlertView key={i} alert={a as GroupAlert} remove={this.removeAlert} />;
                 }
                 case 'Progression': {
-                  return <ProgressionAlertView key={i} alert={a as ProgressionAlert} remove={this.removeAlert} />
+                  return <ProgressionAlertView key={i} alert={a as ProgressionAlert} remove={this.removeAlert} />;
                 }
               }
               return null;

--- a/game/hud/src/components/Progression/RewardsView.tsx
+++ b/game/hud/src/components/Progression/RewardsView.tsx
@@ -133,7 +133,7 @@ class RewardsView extends React.Component<Props, State> {
               <LoadingContainer>
                 <div>{graphql.lastError}</div>
               </LoadingContainer>
-            )
+            );
           }
           if (graphql.loading || !graphql.data || !graphql.data.myprogression) {
             return (

--- a/game/hud/src/components/Progression/index.tsx
+++ b/game/hud/src/components/Progression/index.tsx
@@ -127,7 +127,7 @@ class Progression extends React.Component<Props, State> {
       collecting: false,
       collected: false,
       logIDs: [],
-    }
+    };
   }
   public render() {
     if (!this.state.visible) {
@@ -207,13 +207,13 @@ class Progression extends React.Component<Props, State> {
     this.setState({ collecting: true });
     this.collectCharacterDayProgression(0);
   }
-  
+
   private collectCharacterDayProgression = async (logIDIndex: number) => {
     if (!this.state.logIDs[logIDIndex]) {
       // set a timeout for the api server to update
       this.setState({ collecting: false, collected: true });
       return;
-    };
+    }
     try {
       const res = await webAPI.ProgressionAPI.CollectCharacterDayProgression(
         webAPI.defaultConfig,
@@ -231,7 +231,7 @@ class Progression extends React.Component<Props, State> {
 
       // Recursively collect next days character progression
       this.collectCharacterDayProgression(logIDIndex + 1);
-    } catch(err) {
+    } catch (err) {
       console.error(err);
     }
   }

--- a/game/hud/src/services/actions/trade.ts
+++ b/game/hud/src/services/actions/trade.ts
@@ -25,7 +25,7 @@ export async function inviteToTrade(targetID: string) {
         toastr.error(resultData.FieldCodes[0].Message, 'Oh No!!', { timeout: 3000 });
       }
     }
-  } catch(e) {
+  } catch (e) {
     console.error(e);
   }
 }

--- a/game/hud/src/widgets/Crafting/services/game/crafting/queryTypes.ts
+++ b/game/hud/src/widgets/Crafting/services/game/crafting/queryTypes.ts
@@ -80,7 +80,7 @@ interface VoxRecipe {
     isVox: boolean;
     itemType: string;
     name: string;
-  }
+  };
   outputItem: {
     name: string;
     iconUrl: string;

--- a/game/hud/src/widgets/Crafting/services/session/job.ts
+++ b/game/hud/src/widgets/Crafting/services/session/job.ts
@@ -237,7 +237,7 @@ export const gotVoxPossibleIngredientsForSlot = module.createAction({
       possibleIngredientsForSlot: a.ingredients
         && mapVoxIngredientsToIngredients(a.ingredients).sort((a, b) => a.name.localeCompare(b.name)),
       slot: a.slot,
-    }
+    };
   },
 });
 

--- a/game/hud/src/widgets/Crafting/services/session/recipes.ts
+++ b/game/hud/src/widgets/Crafting/services/session/recipes.ts
@@ -76,7 +76,7 @@ export const gotVoxRecipes = module.createAction({
       }
     }
     console.error('CRAFTING: illegal recipe type ' + type);
-    
+
     return {};
   },
 });

--- a/game/hud/src/widgets/HUDFullScreen/components/Inventory/components/InventoryBody.tsx
+++ b/game/hud/src/widgets/HUDFullScreen/components/Inventory/components/InventoryBody.tsx
@@ -326,11 +326,11 @@ class InventoryBody extends React.Component<InventoryBodyProps, InventoryBodySta
   }
 
   private removeRowOfSlots = (rowData: InventorySlotItemDef[][]) => {
-    this.setState((state) => base.removeRowOfSlots(state, rowData, this.state.heightOfBody));
+    this.setState(state => base.removeRowOfSlots(state, rowData, this.state.heightOfBody));
   }
 
   private pruneRowsOfSlots = (rowData: InventorySlotItemDef[][]) => {
-    this.setState((state) => base.pruneRowsOfSlots(state, rowData, this.state.heightOfBody));
+    this.setState(state => base.pruneRowsOfSlots(state, rowData, this.state.heightOfBody));
   }
 
   private onUpdateInventoryOnEquip = (payload: UpdateInventoryItemsPayload) => {

--- a/game/hud/src/widgets/HUDFullScreen/components/Inventory/index.tsx
+++ b/game/hud/src/widgets/HUDFullScreen/components/Inventory/index.tsx
@@ -54,7 +54,7 @@ export interface InventoryProps {
   myTradeItems: InventoryItemFragment[];
   myTradeState: SecureTradeState;
   containerIdToDrawerInfo: ContainerIdToDrawerInfo;
-  stackGroupIdToItemIDs: {[id: string]: string[]}
+  stackGroupIdToItemIDs: {[id: string]: string[]};
   onChangeInventoryItems: (inventoryItems: InventoryItemFragment[]) => void;
   onChangeContainerIdToDrawerInfo: (newObj: ContainerIdToDrawerInfo) => void;
   onChangeStackGroupIdToItemIDs: (newObj: {[id: string]: string[]}) => void;

--- a/game/hud/src/widgets/HUDFullScreen/components/ItemShared/InventoryBase.tsx
+++ b/game/hud/src/widgets/HUDFullScreen/components/ItemShared/InventoryBase.tsx
@@ -848,7 +848,7 @@ export function distributeItemsNoFilter(slotsData: {
 export function getContainerIdToDrawerInfo(containerItems: InventoryItemFragment[],
                                             containerIdToDrawerInfo: ContainerIdToDrawerInfo,
                                             moveRequests?: MoveItemRequest[]) {
-  const newContainerIdToDrawerInfo = {...containerIdToDrawerInfo};
+  const newContainerIdToDrawerInfo = { ...containerIdToDrawerInfo };
   const newMoveRequests = moveRequests && [...moveRequests];
 
   containerItems.forEach((_containerItem) => {
@@ -930,7 +930,7 @@ export function getContainerIdToDrawerInfo(containerItems: InventoryItemFragment
   return {
     newContainerIdToDrawerInfo,
     newMoveRequests,
-  }
+  };
 }
 
 // we're filtering items here, put items into slots without regard to position

--- a/game/hud/src/widgets/HUDFullScreen/components/TradeWindow/components/TradeDropContainer.tsx
+++ b/game/hud/src/widgets/HUDFullScreen/components/TradeWindow/components/TradeDropContainer.tsx
@@ -8,7 +8,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import styled from 'react-emotion';
-import { ql, webAPI, client } from '@csegames/camelot-unchained'
+import { ql, webAPI, client } from '@csegames/camelot-unchained';
 
 import LockedOverlay from './LockedOverlay';
 import withDragAndDrop, { DragAndDropInjectedProps, DragEvent } from '../../../../../components/DragAndDrop/DragAndDrop';
@@ -230,7 +230,7 @@ class TradeContainer extends React.Component<TradeDropContainerProps, TradeDropC
           const parsedRes = webAPI.parseResponseData(res);
           toastr.error(parsedRes.FieldCodes[0].Message, parsedRes.Message, { timeout: 2500 });
         }
-      } catch(err) {
+      } catch (err) {
         toastr.error('There was an error!', 'Oh No!!', { timeout: 2500 });
       }
     }
@@ -275,7 +275,7 @@ class TradeContainer extends React.Component<TradeDropContainerProps, TradeDropC
           }
         });
       });
-    } catch(err) {
+    } catch (err) {
       toastr.error('There was an error!', 'Oh No!!', { timeout: 2500 });
     }
   }
@@ -299,7 +299,7 @@ class TradeContainer extends React.Component<TradeDropContainerProps, TradeDropC
         const parsedResData = webAPI.parseResponseData(res).data;
         toastr.error(parsedResData.FieldCodes[0].Message, parsedResData.Message, { timeout: 2500 });
       }
-    } catch(err) {
+    } catch (err) {
       toastr.error('There was an error!', 'Oh No!!', { timeout: 2500 });
     }
   }
@@ -394,7 +394,7 @@ const TradeDropContainer = withDragAndDrop<TradeDropContainerProps>(
       dataKey: 'inventory-items',
       dropTarget: props.tradeState !== 'Locked' && props.tradeState !== 'None' && props.id === 'myItems',
       disableDrag: true,
-    }
+    };
   },
 )(TradeContainer);
 

--- a/game/hud/src/widgets/HUDFullScreen/components/TradeWindow/components/TradeWindowMidSection.tsx
+++ b/game/hud/src/widgets/HUDFullScreen/components/TradeWindow/components/TradeWindowMidSection.tsx
@@ -162,7 +162,7 @@ class TradeWindowMidSection extends React.Component<TradeWindowMidSectionProps, 
         const parsedResData = webAPI.parseResponseData(res).data;
         toastr.error(parsedResData.FieldCodes[0].Message, parsedResData.Message, { timeout: 2500 });
       }
-    } catch(err) {
+    } catch (err) {
       toastr.error('There was an error!', 'Oh no!!', { timeout: 2500 });
     }
   }
@@ -185,7 +185,7 @@ class TradeWindowMidSection extends React.Component<TradeWindowMidSectionProps, 
         const parsedResData = webAPI.parseResponseData(res).data;
         toastr.error(parsedResData.FieldCodes[0].Message, parsedResData.Message, { timeout: 2500 });
       }
-    } catch(err) {
+    } catch (err) {
       toastr.error('There was an error!', 'Oh no!!', { timeout: 2500 });
     }
   }
@@ -205,7 +205,7 @@ class TradeWindowMidSection extends React.Component<TradeWindowMidSectionProps, 
         const parsedResData = webAPI.parseResponseData(res).data;
         toastr.error(parsedResData.FieldCodes[0].Message, parsedResData.Message, { timeout: 2500 });
       }
-    } catch(err) {
+    } catch (err) {
       toastr.error('There was an error!', 'Oh no!!', { timeout: 2500 });
     }
   }
@@ -225,7 +225,7 @@ class TradeWindowMidSection extends React.Component<TradeWindowMidSectionProps, 
         const parsedResData = webAPI.parseResponseData(res).data;
         toastr.error(parsedResData.FieldCodes[0].Message, parsedResData.Message, { timeout: 2500 });
       }
-    } catch(err) {
+    } catch (err) {
       toastr.error('There was an error!', 'Oh no!!', { timeout: 2500 });
     }
   }

--- a/game/hud/src/widgets/HUDFullScreen/components/TradeWindow/components/TradeWindowView.tsx
+++ b/game/hud/src/widgets/HUDFullScreen/components/TradeWindow/components/TradeWindowView.tsx
@@ -117,7 +117,7 @@ class TradeWindowView extends React.Component<TradeWindowViewProps, TradeWindowV
         <CancelButton onClick={this.onCancelClick}>Cancel</CancelButton>
         <TabHeader title='TRADE' />
         <TradeWindowSubHeader
-          text="Your Offer"
+          text='Your Offer'
           borderColor={'rgba(217, 188, 141, 0.2)'}
           backgroundColor={'rgba(217, 188, 141, 0.3)'}
           borderBackgroundColor={'rgba(217, 188, 141, 0.3)'}
@@ -143,7 +143,7 @@ class TradeWindowView extends React.Component<TradeWindowViewProps, TradeWindowV
           onTheirTradeStateChanged={this.props.onTheirTradeStateChange}
         />
         <TradeWindowSubHeader
-          text="You will receive"
+          text='You will receive'
           useGrayBG={true}
           borderColor={'rgba(223, 223, 223, 0.2)'}
           backgroundColor={'rgba(223, 223, 223, 0.3)'}
@@ -190,7 +190,7 @@ class TradeWindowView extends React.Component<TradeWindowViewProps, TradeWindowV
   }
 
   private setDropContainerDimensions = () => {
-    const { clientWidth, clientHeight } = this.tradeDropContainerRef; 
+    const { clientWidth, clientHeight } = this.tradeDropContainerRef;
     if (clientWidth !== this.state.dropContainerWidth || clientHeight !== this.state.dropContainerHeight) {
       this.setState({ dropContainerWidth: clientWidth, dropContainerHeight: clientHeight });
     }
@@ -220,7 +220,7 @@ class TradeWindowView extends React.Component<TradeWindowViewProps, TradeWindowV
         const parsedResData = webAPI.parseResponseData(res).data;
         toastr.error(parsedResData.FieldCodes[0].Message, parsedResData.Message, { timeout: 2500 });
       }
-    } catch(err) {
+    } catch (err) {
       toastr.error('There was an error!', 'Oh no!!', { timeout: 2500 });
     }
   }
@@ -229,7 +229,7 @@ class TradeWindowView extends React.Component<TradeWindowViewProps, TradeWindowV
     const items = this.props.theirTradeItems;
     const containerItems: InventoryItemFragment[] = [];
     const theirStackGroupIdToItemIDs: {[id: string]: string[]} = {};
-    
+
     items.forEach((item) => {
       if (isContainerItem(item)) {
         containerItems.push(item);
@@ -263,7 +263,7 @@ class TradeWindowView extends React.Component<TradeWindowViewProps, TradeWindowV
           ...state,
           theirStackGroupIdToItemIDs,
           theirContainerIdToDrawerInfo,
-        }
+        };
       });
     }
   }

--- a/game/hud/src/widgets/HUDFullScreen/components/TradeWindow/index.tsx
+++ b/game/hud/src/widgets/HUDFullScreen/components/TradeWindow/index.tsx
@@ -27,7 +27,7 @@ import { InventoryItemFragment } from '../../../../gqlInterfaces';
 
 type QueryType = {
   secureTrade: SecureTradeStatus;
-}
+};
 
 const tradeQuery = `
   {

--- a/game/hud/tslint.json
+++ b/game/hud/tslint.json
@@ -31,7 +31,7 @@
       "check-branch",
       "check-decl",
       "check-operator",
-      "check-separator",
+      "(causes-stack-overflow):check-separator",
       "check-rest-spread",
       "check-type",
       "check-typecast",


### PR DESCRIPTION
Since lint has been broken, a bunch of lint errors have crept in.  This PR addresses those and also (temporarily) disables the "check-separator" rule which is what is currently crashing lint.  Once there is a fix for tslint, we should ofc re-enable this option.