### PR TITLE
Add Error and Fatal error alerts.

### DIFF
--- a/patcher/src/services/patcher/index.ts
+++ b/patcher/src/services/patcher/index.ts
@@ -59,6 +59,11 @@ export interface Channel {
   lastUpdated: number;
 }
 
+export interface PatcherError {
+  message: string;
+  fatal: boolean;
+}
+
 const API : string = 'patcherAPI';
 
 // Define patcher class
@@ -226,6 +231,22 @@ export class PatcherAPI {
   public maximizeWindow() {
     this._api.maxmizeWindow();
   }
+
+  public onError(handler: (error: PatcherError) => void) {
+    /*
+    function fakeIt() {
+      if (Date.now() % 10 < 9) {
+        handler({ message: 'Test non-fatal message', fatal: false });
+      } else {
+        handler({ message: 'Test fatal message', fatal: true });
+      }
+      setTimeout(fakeIt, 10000);
+    }
+    setTimeout(fakeIt, 10000);
+    */
+    if (this._api.OnPatcherError) this._api.OnPatcherError(handler);
+  }
+
   private getChannelValue(channel:Channel) : number {
     // force sort order to Hatchery, Wyrmling, Other Channels, and Editor last
     if (channel.channelID === 4) return 0; // Hatchery

--- a/patcher/src/services/patcher/index.ts
+++ b/patcher/src/services/patcher/index.ts
@@ -233,17 +233,6 @@ export class PatcherAPI {
   }
 
   public onError(handler: (error: PatcherError) => void) {
-    /*
-    function fakeIt() {
-      if (Date.now() % 10 < 9) {
-        handler({ message: 'Test non-fatal message', fatal: false });
-      } else {
-        handler({ message: 'Test fatal message', fatal: true });
-      }
-      setTimeout(fakeIt, 10000);
-    }
-    setTimeout(fakeIt, 10000);
-    */
     if (this._api.OnPatcherError) this._api.OnPatcherError(handler);
   }
 

--- a/patcher/src/widgets/Controller/components/ControllerDisplay/components/ControllerDisplayView.tsx
+++ b/patcher/src/widgets/Controller/components/ControllerDisplay/components/ControllerDisplayView.tsx
@@ -11,6 +11,8 @@ import { webAPI } from '@csegames/camelot-unchained';
 
 import Login from '../../Login';
 import Alerts from '../../Alerts';
+import PatcherError from '../../PatcherError';
+import FatalError from '../../FatalError';
 import PatchButton from '../../PatchButton';
 import CharacterSelect from '../../CharacterSelect';
 import ProgressBar from '../../ProgressBar';
@@ -59,6 +61,7 @@ export interface ControllerDisplayViewProps {
   selectCharacter: (character: webAPI.SimpleCharacter) => void;
   selectServer: (server: PatcherServer) => void;
   selectServerType: (serverType: ServerType) => void;
+  onClearError: () => void;
 }
 
 export interface ControllerDisplayViewState {
@@ -75,17 +78,26 @@ class ControllerDisplayView extends React.Component<ControllerDisplayViewProps, 
 
   public render() {
     const { activeRoute } = this.props;
-    const { alerts, servers, characters } = this.props.controllerState;
+    const { alerts, servers, characters, errors } = this.props.controllerState;
     const selectedServer = this.props.selectedServer ? servers[this.props.selectedServer.name] : null;
     const selectedCharacter = this.props.selectedCharacter ? characters[this.props.selectedCharacter.id] : null;
     const alertArray: webAPI.PatcherAlert[] = [];
     for (const key in alerts) alertArray.push(alerts[key]);
+
+    if (errors && errors.length) {
+      for (let i = 0; i < errors.length; i++) {
+        if (errors[i].fatal) {
+          return <FatalError errors={errors}/>;
+        }
+      }
+    }
 
     if (!patcher.hasLoginToken()) {
       return (
         <Container>
           <Login onLogin={this.props.onLogin} />
           <Alerts alerts={alertArray} />
+          <PatcherError errors={errors} onClear={this.props.onClearError}/>
         </Container>
       );
     }
@@ -132,6 +144,8 @@ class ControllerDisplayView extends React.Component<ControllerDisplayViewProps, 
           servers={this.props.controllerState.servers}
           selectedServer={selectedServer}
         />
+        <Alerts alerts={alertArray} />
+        <PatcherError errors={errors} onClear={this.props.onClearError}/>
       </Container>
     );
   }
@@ -140,7 +154,7 @@ class ControllerDisplayView extends React.Component<ControllerDisplayViewProps, 
     if (this.state.initialCharSelectOpen && !this.props.charSelectVisible && nextProps.charSelectVisible) {
       this.setState({ initialCharSelectOpen: false });
     }
-  } 
+  }
 }
 
 export default ControllerDisplayView;

--- a/patcher/src/widgets/Controller/components/ControllerDisplay/index.tsx
+++ b/patcher/src/widgets/Controller/components/ControllerDisplay/index.tsx
@@ -19,6 +19,8 @@ import {
   ServerType,
   initialize,
   characterRemoved,
+  listenForErrors,
+  clearError,
 } from '../../services/session/controller';
 
 export interface APIServerStatus {
@@ -73,6 +75,7 @@ class ControllerDisplay extends React.Component<ControllerDisplayProps, Controll
         onChooseCharacter={this.onChooseCharacter}
         onToggleCharacterSelect={this.toggleCharacterSelect}
         onDeleteCharacterSuccess={this.onDeleteCharacterSuccess}
+        onClearError={this.onClearError}
         selectCharacter={this.selectCharacter}
         selectServer={this.selectServer}
         selectServerType={this.selectServerType}
@@ -83,6 +86,7 @@ class ControllerDisplay extends React.Component<ControllerDisplayProps, Controll
 
   public componentDidMount() {
     this.getServers();
+    this.props.dispatch(listenForErrors());
   }
 
   private getServers = async () => {
@@ -101,6 +105,10 @@ class ControllerDisplay extends React.Component<ControllerDisplayProps, Controll
 
   private onLogin = () => {
     this.props.dispatch(initialize());
+  }
+
+  private onClearError = () => {
+    this.props.dispatch(clearError());
   }
 
   private toggleCharacterSelect = () => {

--- a/patcher/src/widgets/Controller/components/FatalError/index.tsx
+++ b/patcher/src/widgets/Controller/components/FatalError/index.tsx
@@ -1,0 +1,55 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import * as React from 'react';
+import styled from 'react-emotion';
+import { PatcherError } from '../../../../services/patcher';
+
+const Background = styled('div')`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0,0,0,0.9);
+  z-index: 100;
+`;
+
+const Dialog = styled('div')`
+  overflow: hidden;
+  background: repeating-linear-gradient(45deg, #600000, #600000 2px, #6F0000 2px, #6F0000 5px);
+  border-top: 3px solid #600000;
+  border-bottom: 3px solid #600000;
+  color: #ececec;
+  padding: 3px 15px;
+  position: fixed;
+  left: 25%;
+  top: 25%;
+  bottom: 25%;
+  right: 25%;
+  text-align: center;
+  z-index: 101;
+  overflow-y: auto;
+`;
+
+export interface FatalErrorProps {
+  errors: PatcherError[];
+}
+
+/* tslint:disable:function-name */
+function FatalError(props: FatalErrorProps) {
+  if (props.errors.length === 0) return null;
+  return (
+    <Background>
+      <Dialog>
+        { props.errors.map((error: PatcherError) => <div>{error.message}</div>) }
+        <div>Please Restart the Patcher</div>
+      </Dialog>
+    </Background>
+  );
+}
+
+export default FatalError;

--- a/patcher/src/widgets/Controller/components/PatcherError/index.tsx
+++ b/patcher/src/widgets/Controller/components/PatcherError/index.tsx
@@ -10,11 +10,11 @@ import { PatcherError } from '../../../../services/patcher';
 
 const Alert = styled('div')`
   overflow: hidden;
-  background-color: orange;
+  background: repeating-linear-gradient(45deg, darkorange, orange 2px, orange 1px, darkorange 4px);
   color: black;
   padding: 3px 15px;
   position: relative;
-  pointer-events: bounding-box;
+  pointer-events: all;
   cursor: pointer;
   ::after {
     content: 'X';
@@ -28,7 +28,7 @@ const Alert = styled('div')`
 
 export interface PatcherErrorProps {
   errors: PatcherError[];
-  onClear?: any;
+  onClear?: () => void;
 }
 
 /* tslint:disable:function-name */

--- a/patcher/src/widgets/Controller/components/PatcherError/index.tsx
+++ b/patcher/src/widgets/Controller/components/PatcherError/index.tsx
@@ -1,0 +1,43 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import * as React from 'react';
+import styled from 'react-emotion';
+import { PatcherError } from '../../../../services/patcher';
+
+const Alert = styled('div')`
+  overflow: hidden;
+  background-color: orange;
+  color: black;
+  padding: 3px 15px;
+  position: relative;
+  pointer-events: bounding-box;
+  cursor: pointer;
+  ::after {
+    content: 'X';
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: 30px;
+    pointer-events: none;
+  }
+`;
+
+export interface PatcherErrorProps {
+  errors: PatcherError[];
+  onClear?: any;
+}
+
+/* tslint:disable:function-name */
+function PatcherError(props: PatcherErrorProps) {
+  if (props.errors.length === 0) return null;
+  return <Alert onClick={props.onClear}>
+    { props.errors.length > 1 ? `(1/${props.errors.length}) ` : '' }
+    { props.errors[0].message }
+  </Alert>;
+}
+
+export default PatcherError;


### PR DESCRIPTION
Normal errors are displayed in an orange bar at the bottom of the screen.  If there is more than one error the first is displayed and an indicator of how many other errors exist.  Clicking the bar clears that error, showing the next error if there is one.

If the error is fatal, a fatal error dialog is shown that prevents further use of the patcher with a message asking the user to restart the patcher.  If other errors were received before the fatal error, they are also displayed in the dialog.