### PR TITLE
added HealthSlideOut and helper functions to compact and full health bars

### DIFF
--- a/game/hud/src/components/HealthBar/components/HealthBarViewCompact.tsx
+++ b/game/hud/src/components/HealthBar/components/HealthBarViewCompact.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import styled from 'react-emotion';
 import { Faction, PlayerState, GroupMemberState } from '@csegames/camelot-unchained';
 
-import { getFaction } from '../lib/healthFunctions';
+import { getFaction, getBodyPartsCurrentHealth } from '../lib/healthFunctions';
 import { isEqualPlayerState } from '../../../lib/playerStateEqual';
 import { BodyParts } from '../../../lib/PlayerStatus';
 import ClassIndicator from './ClassIndicator';
@@ -17,7 +17,7 @@ import SmallBar from './SmallBar';
 import BigBar from './BigBar';
 import StaminaBar from './StaminaBar';
 import BloodBall from './BloodBall';
-// import HealthSlideOut from './HealthSlideOut';
+import HealthSlideOut from './HealthSlideOut';
 
 const Container = styled('div')`
   position: relative;
@@ -96,10 +96,17 @@ export interface HealthBarViewProps {
 }
 
 export interface HealthBarViewState {
-
+  mouseOver: boolean;
 }
 
 class HealthBarView extends React.Component<HealthBarViewProps, HealthBarViewState> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      mouseOver: false,
+    };
+  }
+
   public render() {
     const { playerState } = this.props;
     const factionColor = {
@@ -109,23 +116,23 @@ class HealthBarView extends React.Component<HealthBarViewProps, HealthBarViewSta
     };
     const faction = getFaction(playerState);
     return (
-      <Container shouldShake={this.props.shouldShake} isAlive={this.props.playerState.isAlive}>
+      <Container shouldShake={this.props.shouldShake}
+        isAlive={this.props.playerState.isAlive}
+        onMouseOver={this.handleMouseOver}
+        onMouseLeave={this.handleMouseOut}
+        >
         <NameContainer factionColor={factionColor[faction]}>
           <Name>{this.props.playerState.name}</Name>
         </NameContainer>
         <ClassIndicator scale={1} top={15} left={140} width={75} height={75} borderRadius={37.5} faction={faction} />
         <BloodBall playerState={playerState} />
-        {/*
-          This is commented out because it will not be shown by default but will be a toggle in the options menu.
-          The toggle in the options menu has not been built yet so for now just hiding this.
           <HealthSlideOut
-            right={-45}
+            right={this.state.mouseOver ? -50 : -20}
+            valueOpacity={this.state.mouseOver ? 1 : 0}
             height={208}
-            currentStamina={this.props.currentStamina}
-            bodyPartsCurrentHealth={this.props.bodyPartsCurrentHealth}
+            currentStamina={playerState.stamina.current}
+            bodyPartsCurrentHealth={getBodyPartsCurrentHealth(playerState)}
           />
-        */}
-
         <HealthPillsContainer>
           <SmallBar height={21} scale={1} bodyPart={BodyParts.RightArm} playerState={playerState} />
           <SmallBar height={21} scale={1} bodyPart={BodyParts.LeftArm} playerState={playerState} />
@@ -144,7 +151,16 @@ class HealthBarView extends React.Component<HealthBarViewProps, HealthBarViewSta
   }
 
   public shouldComponentUpdate(nextProps: HealthBarViewProps, nextState: HealthBarViewState) {
-    return !isEqualPlayerState(nextProps.playerState, this.props.playerState);
+    return !isEqualPlayerState(nextProps.playerState, this.props.playerState) ||
+      nextState.mouseOver !== this.state.mouseOver;
+  }
+
+  private handleMouseOver = () => {
+    this.setState({ mouseOver: true });
+  }
+
+  private handleMouseOut = () => {
+    this.setState({ mouseOver: false });
   }
 }
 

--- a/game/hud/src/components/HealthBar/components/HealthBarViewFull.tsx
+++ b/game/hud/src/components/HealthBar/components/HealthBarViewFull.tsx
@@ -11,11 +11,11 @@ import { PlayerState, GroupMemberState } from '@csegames/camelot-unchained';
 
 import { isEqualPlayerState } from '../../../lib/playerStateEqual';
 import { BodyParts } from '../../../lib/PlayerStatus';
-import { getBloodPercent, getStaminaPercent, getFaction } from '../lib/healthFunctions';
+import { getBloodPercent, getStaminaPercent, getFaction, getBodyPartsCurrentHealth } from '../lib/healthFunctions';
 import ClassIndicator from './ClassIndicator';
 import SmallBar from './SmallBar';
 import BigBar from './BigBar';
-// import HealthSlideOut from './HealthSlideOut';
+import HealthSlideOut from './HealthSlideOut';
 
 const Container = styled('div')`
   position: relative;
@@ -139,17 +139,28 @@ export interface HealthBarViewProps {
 }
 
 export interface HealthBarViewState {
-
+  mouseOver: boolean;
 }
 
 class HealthBarView extends React.Component<HealthBarViewProps, HealthBarViewState> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      mouseOver: false,
+    };
+  }
+
   public render() {
     const { playerState } = this.props;
     const bloodPercent = getBloodPercent(playerState);
     const staminaPercent = getStaminaPercent(playerState);
     const faction = getFaction(playerState);
     return (
-      <Container shouldShake={this.props.shouldShake} isAlive={playerState.isAlive}>
+      <Container
+      shouldShake={this.props.shouldShake}
+      isAlive={playerState.isAlive}
+      onMouseOver={this.handleMouseOver}
+      onMouseLeave={this.handleMouseOut}>
         <ContentContainer>
           <NameContainer>
             <Name>{playerState.name}</Name>
@@ -158,12 +169,13 @@ class HealthBarView extends React.Component<HealthBarViewProps, HealthBarViewSta
           <BloodBall percent={bloodPercent}>
             {/* <BloodCount>{this.props.currentBlood}</BloodCount> */}
           </BloodBall>
-          {/* <HealthSlideOut
-            right={65}
+          <HealthSlideOut
+            valueOpacity={this.state.mouseOver ? 1 : 0}
+            right={this.state.mouseOver ? 70 : 100}
             height={208}
-            currentStamina={this.props.currentStamina}
-            bodyPartsCurrentHealth={this.props.bodyPartsCurrentHealth}
-          /> */}
+            currentStamina={playerState.stamina.current}
+            bodyPartsCurrentHealth={getBodyPartsCurrentHealth(playerState)}
+          />
           <HealthPillsContainer>
             <SmallBar height={21} scale={1} bodyPart={BodyParts.RightArm} playerState={playerState} />
             <SmallBar height={21} scale={1} bodyPart={BodyParts.LeftArm} playerState={playerState} />
@@ -180,7 +192,16 @@ class HealthBarView extends React.Component<HealthBarViewProps, HealthBarViewSta
   }
 
   public shouldComponentUpdate(nextProps: HealthBarViewProps, nextState: HealthBarViewState) {
-    return !isEqualPlayerState(this.props.playerState, nextProps.playerState);
+    return !isEqualPlayerState(this.props.playerState, nextProps.playerState) ||
+      nextState.mouseOver !== this.state.mouseOver;
+  }
+
+  private handleMouseOver = () => {
+    this.setState({ mouseOver: true });
+  }
+
+  private handleMouseOut = () => {
+    this.setState({ mouseOver: false });
   }
 }
 

--- a/game/hud/src/components/HealthBar/components/HealthSlideOut.tsx
+++ b/game/hud/src/components/HealthBar/components/HealthSlideOut.tsx
@@ -17,6 +17,8 @@ const Container = styled('div')`
   height: ${(props: any) => props.height.toFixed(1)}px;
   width: 71px;
   background: url(images/healthbar/regular/slide_out.png);
+  transition: right 0.5s;
+  -webkit-transition: right 0.5s;
 `;
 
 const ValuesContainer = styled('div')`
@@ -35,6 +37,7 @@ const Value = styled('div')`
   text-align: center;
   font-size: 16px;
   line-height: 16px;
+  -webkit-transition: opacity 0.5s;
 `;
 
 export interface HealthSlideOutProps {
@@ -42,6 +45,7 @@ export interface HealthSlideOutProps {
   right: number;
   bodyPartsCurrentHealth: number[];
   currentStamina: number;
+  valueOpacity: number;
 }
 
 export interface HealthSlideOutState {
@@ -54,21 +58,21 @@ class HealthSlideOut extends React.Component<HealthSlideOutProps, HealthSlideOut
     return (
       <Container right={this.props.right} height={this.props.height}>
         <ValuesContainer marginLeft={10} height={45}>
-          <Value>{bodyPartsCurrentHealth[BodyParts.RightArm]}</Value>
-          <Value>{bodyPartsCurrentHealth[BodyParts.LeftArm]}</Value>
+          <Value style={{ opacity: this.props.valueOpacity }}>{bodyPartsCurrentHealth[BodyParts.RightArm]}</Value>
+          <Value style={{ opacity: this.props.valueOpacity }}>{bodyPartsCurrentHealth[BodyParts.LeftArm]}</Value>
         </ValuesContainer>
-        <ValuesContainer marginLeft={20} height={48}>
-          <Value>{bodyPartsCurrentHealth[BodyParts.Head]}</Value>
+        <ValuesContainer marginLeft={18} height={48}>
+          <Value style={{ opacity: this.props.valueOpacity }}>{bodyPartsCurrentHealth[BodyParts.Head]}</Value>
         </ValuesContainer>
-        <ValuesContainer marginLeft={20} height={48}>
-          <Value>{bodyPartsCurrentHealth[BodyParts.Torso]}</Value>
+        <ValuesContainer marginLeft={18} height={48}>
+          <Value style={{ opacity: this.props.valueOpacity }}>{bodyPartsCurrentHealth[BodyParts.Torso]}</Value>
         </ValuesContainer>
         <ValuesContainer marginLeft={10} height={45}>
-          <Value>{bodyPartsCurrentHealth[BodyParts.RightLeg]}</Value>
-          <Value>{bodyPartsCurrentHealth[BodyParts.LeftLeg]}</Value>
+          <Value style={{ opacity: this.props.valueOpacity }}>{bodyPartsCurrentHealth[BodyParts.RightLeg]}</Value>
+          <Value style={{ opacity: this.props.valueOpacity }}>{bodyPartsCurrentHealth[BodyParts.LeftLeg]}</Value>
         </ValuesContainer>
         <ValuesContainer marginLeft={10} height={20}>
-          <Value>{currentStamina}</Value>
+          <Value style={{ opacity: this.props.valueOpacity }}>{currentStamina}</Value>
         </ValuesContainer>
       </Container>
     );
@@ -76,7 +80,7 @@ class HealthSlideOut extends React.Component<HealthSlideOutProps, HealthSlideOut
 
   public shouldComponentUpdate(nextProps: HealthSlideOutProps) {
     return !_.isEqual(nextProps.bodyPartsCurrentHealth, this.props.bodyPartsCurrentHealth) ||
-      nextProps.currentStamina !== this.props.currentStamina;
+      nextProps.currentStamina !== this.props.currentStamina || nextProps.right !== this.props.right;
   }
 }
 

--- a/game/hud/src/components/HealthBar/lib/healthFunctions.ts
+++ b/game/hud/src/components/HealthBar/lib/healthFunctions.ts
@@ -48,3 +48,7 @@ export function getFaction(playerState: PlayerState | GroupMemberState) {
 
   return playerState.faction;
 }
+
+export function getBodyPartsCurrentHealth(playerState: PlayerState | GroupMemberState) {
+  return playerState.health.map(bodypart => bodypart.current)
+}


### PR DESCRIPTION
If you have any suggestions, improvements, or additional functionality you'd like added just let me know and I will be happy to make the changes.

changes made:

### HealthBarViewCompact.tsx
 - added `mouseOver` property to state
 - added functions to handle `onMouseOver` and `onMouseLeave`
 - added `HealthSlideOut` component

### HealthBarViewFull.tsx
 - added `mouseOver` state
 - added functions to handle `onMouseOver` and `onMouseLeave`
 - added `HealthSlideOut` component

### healthFunctions.ts
 - added `getBodyPartsCurrentHealth()` function to return array of all body parts health

### HealthSlideOut.tsx
- added transition: right for animations
- added `valueOpacity` and transition: opacity to HP values to cause make them 'fade-in' on mouse-over
- adjusted `marginLeft` on middle two `ValueContainer` to fix numbers touching the right border