### PR TITLE
Move watermark above zone name widget and increase z-index.

### DIFF
--- a/game/hud/src/components/Watermark.tsx
+++ b/game/hud/src/components/Watermark.tsx
@@ -12,18 +12,17 @@ const Watermark = styled('i')`
   height: 20px;
   line-height: 20px;
   position: fixed;
-  left: 50%;
-  top: 15px;
-  transform: translateX(-50%);
+  left: 5px;
+  top: 55px;
   color: #FFF;
   font-size: 13px;
   font-family: 'Merriweather Sans', sans-serif;
-  fotn-weight: bold;
-  text-align: right;
+  font-weight: bold;
   text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
   -webkit-touch-callout: none;
   user-select: none;
   cursor: default;
+  z-index: 9999;
 `;
 
 export interface WatermarkStyle {


### PR DESCRIPTION
This moves the watermark to a spot that's less likely to cover windows (mainly alert dialogs) and increases the z-index, so it is on top of the full-screen UI widgets.