### PR TITLE
Add support for import paths 

### DIFF
--- a/game/hud/aliasify.config.js
+++ b/game/hud/aliasify.config.js
@@ -1,0 +1,11 @@
+var path = require("path");
+module.exports = {
+    replacements: {
+        "^UI/(\\w+)": ".\\tmpp\\components\\UI\\$1",
+        "^lib/(\\w+)": ".\\tmpp\\lib\\$1",
+        "^services/(\\w+)": ".\\tmpp\\services\\$1",
+        "^widgets/(\\w+)": ".\\tmpp\\widgets\\$1",
+        "^components/(\\w+)": ".\\tmpp\\components\\$1",
+    },
+    verbose: false
+};

--- a/game/hud/package.json
+++ b/game/hud/package.json
@@ -54,6 +54,8 @@
       }
     }
   },
+  "browserify": { "transform": [ "aliasify" ] },
+  "aliasify": "./aliasify.config.js",
   "jest": {
     "transform": {
       ".(ts|tsx)": "<rootDir>/../node_modules/ts-jest/preprocessor.js"
@@ -76,6 +78,7 @@
     "@csegames/cu-xmpp-chat": "^0.1.3",
     "@types/ol": "^4.6.1",
     "@types/openlayers": "^4.6.2",
+    "aliasify": "^2.1.0",
     "aphrodite": "^1.1.0",
     "apisauce": "0.3.1",
     "apollo": "^0.2.2",

--- a/game/hud/src/widgets/Settings/SettingsMain.tsx
+++ b/game/hud/src/widgets/Settings/SettingsMain.tsx
@@ -7,7 +7,7 @@
 import * as React from 'react';
 import { client, events } from '@csegames/camelot-unchained';
 
-import { TabbedDialog, DialogButton } from '../../components/UI/TabbedDialog';
+import { TabbedDialog, DialogButton } from 'UI/TabbedDialog';
 import { GeneralSettings } from './tabs/General';
 import { InterfaceSettings } from './tabs/Interface';
 import { AddonSettings } from './tabs/Addon';

--- a/game/hud/src/widgets/Settings/components/Key.tsx
+++ b/game/hud/src/widgets/Settings/components/Key.tsx
@@ -5,7 +5,7 @@
  */
 
 import styled from 'react-emotion';
-import * as CSS from '../../../lib/css-helper';
+import * as CSS from 'lib/css-helper';
 
 export const Key = styled('span')`
   width: fit-content;

--- a/game/hud/src/widgets/Settings/components/KeyBind.tsx
+++ b/game/hud/src/widgets/Settings/components/KeyBind.tsx
@@ -6,8 +6,8 @@
 
 import * as React from 'react';
 import styled from 'react-emotion';
-import * as CSS from '../../../lib/css-helper';
-import { Box } from '../../../components/UI/Box';
+import * as CSS from 'lib/css-helper';
+import { Box } from 'UI/Box';
 import { Key } from './Key';
 
 function spacify(s: string) {

--- a/game/hud/src/widgets/Settings/components/SettingsPanel.tsx
+++ b/game/hud/src/widgets/Settings/components/SettingsPanel.tsx
@@ -12,7 +12,7 @@
 
 import * as React from 'react';
 import styled from 'react-emotion';
-import * as CSS from '../../../lib/css-helper';
+import * as CSS from 'lib/css-helper';
 
 const SettingsPanelContainer = styled('div')`
   ${CSS.IS_COLUMN} ${CSS.EXPAND_TO_FIT}

--- a/game/hud/src/widgets/Settings/components/settingsRenderer.tsx
+++ b/game/hud/src/widgets/Settings/components/settingsRenderer.tsx
@@ -5,9 +5,9 @@
  */
 
 import * as React from 'react';
-import { CheckBoxField } from '../../../components/UI/CheckBoxField';
-import { SliderField } from '../../../components/UI/SliderField';
-import { SubHeading } from '../../../components/UI/SubHeading';
+import { CheckBoxField } from 'UI/CheckBoxField';
+import { SliderField } from 'UI/SliderField';
+import { SubHeading } from 'UI/SubHeading';
 
 interface Setting {
   type: React.Component | Function;

--- a/game/hud/src/widgets/Settings/panels/AudioSettings.tsx
+++ b/game/hud/src/widgets/Settings/panels/AudioSettings.tsx
@@ -7,8 +7,8 @@
 import * as React from 'react';
 import { SettingsPanel } from '../components/SettingsPanel';
 import { cancel, getAudioConfig, ConfigIndex, sendConfigVarChangeMessage } from '../utils/configVars';
-import { CheckBoxField } from '../../../components/UI/CheckBoxField';
-import { SliderField } from '../../../components/UI/SliderField';
+import { CheckBoxField } from 'UI/CheckBoxField';
+import { SliderField } from 'UI/SliderField';
 import { client, events } from '@csegames/camelot-unchained';
 import { Settings, settingsRenderer } from '../components/settingsRenderer';
 

--- a/game/hud/src/widgets/Settings/panels/GraphicSettings.tsx
+++ b/game/hud/src/widgets/Settings/panels/GraphicSettings.tsx
@@ -7,8 +7,8 @@
 import * as React from 'react';
 import { SettingsPanel } from '../components/SettingsPanel';
 import { cancel, getGraphicsConfig, ConfigIndex, sendConfigVarChangeMessage } from '../utils/configVars';
-import { CheckBoxField } from '../../../components/UI/CheckBoxField';
-import { SliderField } from '../../../components/UI/SliderField';
+import { CheckBoxField } from 'UI/CheckBoxField';
+import { SliderField } from 'UI/SliderField';
 import { client, events } from '@csegames/camelot-unchained';
 import { Settings, settingsRenderer } from '../components/settingsRenderer';
 

--- a/game/hud/src/widgets/Settings/panels/InputSettings.tsx
+++ b/game/hud/src/widgets/Settings/panels/InputSettings.tsx
@@ -7,8 +7,8 @@
 import * as React from 'react';
 import { SettingsPanel } from '../components/SettingsPanel';
 import { cancel, getInputConfig, ConfigIndex, sendConfigVarChangeMessage } from '../utils/configVars';
-import { CheckBoxField } from '../../../components/UI/CheckBoxField';
-import { SubHeading } from '../../../components/UI/SubHeading';
+import { CheckBoxField } from 'UI/CheckBoxField';
+import { SubHeading } from 'UI/SubHeading';
 import { client, events } from '@csegames/camelot-unchained';
 import { Settings, settingsRenderer } from '../components/settingsRenderer';
 

--- a/game/hud/src/widgets/Settings/panels/KeybindSettings.tsx
+++ b/game/hud/src/widgets/Settings/panels/KeybindSettings.tsx
@@ -11,11 +11,11 @@ import { getKeyBinds, cancel, ConfigIndex, sendConfigVarChangeMessage } from '..
 import { KeyBind, Listening } from '../components/KeyBind';
 import { keyBinds2KeyConfig, getKeyLabel, KeyBinds } from '../utils/keyboard';
 import { client, events, getVirtualKeyCode } from '@csegames/camelot-unchained';
-import { Box } from '../../../components/UI/Box';
-import { Field } from '../../../components/UI/Field';
+import { Box } from 'UI/Box';
+import { Field } from 'UI/Field';
 import { Key } from '../components/Key';
-import * as CSS from '../../../lib/css-helper';
-import * as CONFIG from '../../../components/UI/config';
+import * as CSS from 'lib/css-helper';
+import * as CONFIG from 'components/UI/config';
 
 interface ClashKey {
   name: string;

--- a/game/hud/src/widgets/Settings/tabs/Addon.tsx
+++ b/game/hud/src/widgets/Settings/tabs/Addon.tsx
@@ -5,8 +5,8 @@
  */
 
 import * as React from 'react';
-import { DialogTab, DialogButton } from '../../../components/UI/TabbedDialog';
-import { SideMenu, MenuOption } from '../../../components/UI/SideMenu';
+import { DialogTab, DialogButton } from 'UI/TabbedDialog';
+import { SideMenu, MenuOption } from 'UI/SideMenu';
 import { ComingSoon } from '../panels/ComingSoon';
 import * as BUTTON from './buttons';
 

--- a/game/hud/src/widgets/Settings/tabs/General.tsx
+++ b/game/hud/src/widgets/Settings/tabs/General.tsx
@@ -7,8 +7,8 @@
 import * as React from 'react';
 import { client, events } from '@csegames/camelot-unchained';
 import { ConfigIndex } from '../utils/configVars';
-import { DialogTab, DialogButton } from '../../../components/UI/TabbedDialog';
-import { SideMenu, MenuOption } from '../../../components/UI/SideMenu';
+import { DialogTab, DialogButton } from 'UI/TabbedDialog';
+import { SideMenu, MenuOption } from 'UI/SideMenu';
 import { KeybindSettings } from '../panels/KeybindSettings';
 import { InputSettings } from '../panels/InputSettings';
 import { GraphicSettings } from '../panels/GraphicSettings';
@@ -16,7 +16,7 @@ import { AudioSettings } from '../panels/AudioSettings';
 import { ComingSoon } from '../panels/ComingSoon';
 import * as BUTTON from './buttons';
 import * as OPTION from './options';
-import { sendSystemMessage } from '../../../services/actions/system';
+import { sendSystemMessage } from 'services/actions/system';
 
 const options: MenuOption[] = [
   OPTION.KEYS,

--- a/game/hud/src/widgets/Settings/tabs/Interface.tsx
+++ b/game/hud/src/widgets/Settings/tabs/Interface.tsx
@@ -5,8 +5,8 @@
  */
 
 import * as React from 'react';
-import { DialogTab, DialogButton } from '../../../components/UI/TabbedDialog';
-import { SideMenu, MenuOption } from '../../../components/UI/SideMenu';
+import { DialogTab, DialogButton } from 'UI/TabbedDialog';
+import { SideMenu, MenuOption } from 'UI/SideMenu';
 import { ComingSoon } from '../panels/ComingSoon';
 import * as BUTTON from './buttons';
 import * as OPTION from './options';

--- a/game/hud/src/widgets/Settings/tabs/buttons.ts
+++ b/game/hud/src/widgets/Settings/tabs/buttons.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { DialogButton } from '../../../components/UI/TabbedDialog';
+import { DialogButton } from 'components/UI/TabbedDialog';
 
 export const APPLY: DialogButton = { label: 'Apply' };
 export const DEFAULT: DialogButton = { label: 'Default' };

--- a/game/hud/src/widgets/Settings/utils/configVars.ts
+++ b/game/hud/src/widgets/Settings/utils/configVars.ts
@@ -9,7 +9,7 @@ import keybinds from './samples/keybindsConfig';
 import input from './samples/inputConfig';
 import audio from './samples/audioConfig';
 import graphics from './samples/graphicsConfig';
-import { sendSystemMessage } from '../../../services/actions/system';
+import { sendSystemMessage } from 'services/actions/system';
 
 function isNotClient() {
   return !!(window['cuOverrides']);

--- a/game/hud/tsconfig.json
+++ b/game/hud/tsconfig.json
@@ -16,7 +16,11 @@
     "experimentalDecorators": true,
     "plugins": [
       { "name": "tslint-language-service"}
-    ]
+    ],
+    "baseUrl": "src",
+    "paths": {
+      "UI/*": [ "components/UI/*" ]
+    }
   },
   "compileOnSave": false,
   "buildOnSave": false,

--- a/game/hud/yarn.lock
+++ b/game/hud/yarn.lock
@@ -306,6 +306,12 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+aliasify@^2.1.0:
+  version "2.1.0"
+  resolved "http://registry.camelotunchained.com/aliasify/-/aliasify-2.1.0.tgz#7c30825b9450b9e6185ba27533eaf6e2067d4b42"
+  dependencies:
+    browserify-transform-tools "~1.7.0"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "http://registry.camelotunchained.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -1344,7 +1350,7 @@ browserify-sign@^4.0.0:
     inherits "^2.0.1"
     parse-asn1 "^5.0.0"
 
-browserify-transform-tools@^1.4.2:
+browserify-transform-tools@^1.4.2, browserify-transform-tools@~1.7.0:
   version "1.7.0"
   resolved "http://registry.camelotunchained.com/browserify-transform-tools/-/browserify-transform-tools-1.7.0.tgz#83e277221f63259bed2e7eb2a283a970a501f4c4"
   dependencies:


### PR DESCRIPTION
*Different parts of the build tools use different terminology for these, but I will call them import paths because that's the TypeScript name for them.*

This PR adds support for import paths.  Import paths are a way to avoid having to use long relative paths in your imports for things that are commonly imported and meant to be shared.

```import { something } from '../../../../../components/something';```

becomes

```import { something } from 'components/something';```

I have setup support for the following import paths:

**components**
**widgets**
**services**
**lib**
**UI**

The first 4 correspond to the main source directories under `src/` and is enabled by the "baseUrl": typescript setting and `UI` maps to `components/UI`.

```import { TabbedDialog } from 'UI/TabbedDialog';```

The `browserify` config was a little bit more involved and required the use of the `aliasify` transform.  Configuration for this is in `aliasify.config.js` next to `package.json`. 

In `aliasify` they are called replacements (think of them like URL rewrite rules) which are regular expressions that match the import path and replace it with what we want.  This is based on the `ttmp` folder structure as this is where `browserify` is working.

I've tested the Settings UI in `npm start dev` after making these changes and everything seems to be working.