### PR TITLE
Healthbar pill height fix

### DIFF
--- a/game/hud/src/components/HealthBar/components/BigBar.tsx
+++ b/game/hud/src/components/HealthBar/components/BigBar.tsx
@@ -16,7 +16,7 @@ const Container = styled('div')`
   left: ${(props: any) => props.left.toFixed(1)}px;
   width: 100%;
   height: ${(props: any) => props.height.toFixed(1)}px;
-  margin-bottom: ${({ scale }: {scale: number}) => (3 * scale).toFixed(1)}px;
+  margin-bottom: 4px;
 `;
 
 const BarContainer = styled('div')`
@@ -25,8 +25,6 @@ const BarContainer = styled('div')`
   right: 0;
   left: 0;
   bottom: 0;
-  width: 100%;
-  height: 100%;
   width: 100%;
   height: 100%;
   background: linear-gradient(to top, #303030, #1D1D1D);


### PR DESCRIPTION
![bighealth2](https://user-images.githubusercontent.com/20871500/42122580-21381398-7c44-11e8-8587-4b35d05ddea7.png)

This is mainly a quick fix I had to find through trial and error, as I didn't have any dev tools. But it is working and the gap between the pills and the background is gone, as you can see it on the image above. This might not be the best and final solution, but it is working for the time being.

Also removed a duplicated height/width from the code.