### PR TITLE
Improve Context Menu behaviour #200

### DIFF
--- a/game/hud/src/components/ContextMenu.tsx
+++ b/game/hud/src/components/ContextMenu.tsx
@@ -17,7 +17,7 @@ const Container = styled('div')`
   right: 0;
   top: 0;
   bottom: 0;
-  z-index: 9999;
+  z-index: 10000;
 `;
 
 const Menu = styled('ol')`
@@ -112,11 +112,14 @@ export class ContextMenu extends React.Component<Props, State> {
     if (this.state.show === false) return null;
 
     return (
-      <Container onClick={this.hide} onKeyDown={this.hide}>
+      <Container onMouseDown={this.hide} onKeyDown={this.hide}>
         <Menu style={this.state.styledPosition}>
           {
             this.state.items &&
               this.state.items.map(item => <Item key={item.title}
+                onMouseDown={(event: MouseEvent) => {
+                  event.stopPropagation();
+                }}
                 onClick={(event: MouseEvent) => {
                   event.stopPropagation();
                   this.hide();

--- a/game/hud/src/services/actions/contextMenu.ts
+++ b/game/hud/src/services/actions/contextMenu.ts
@@ -29,7 +29,7 @@ export type MenuItem = {
 };
 
 export function showContextMenu(items: MenuItem[], event: MouseEvent) {
-  events.fire(ACTIVATE_CONTEXT_MENU, items, event);
+  if (items.length) events.fire(ACTIVATE_CONTEXT_MENU, items, event);
 }
 
 export function onShowContextMenu(callback: (items: MenuItem[], event: MouseEvent) => void) {


### PR DESCRIPTION
This PR goes part way to solving the right click context menu issues described in #200 

It does the following:

1. don't display the context menu if there are no options.  This means that if you happen to right click your own portrait and you are not in a warband you won't get a context menu so it wont steal further right clicks (though it still steals the initial one).

2. if the context menu is open, left or right clicking anywhere but on an option will close it.  This still means that the click to close the menu is stolen from the client, so still steals two right clicks requiring a third to turn.

Also fixed z-order of the menu so the options are not behind the unit frame.

This is not a complete solution to the problem described in #200 