### PR TITLE
Fix brain fried core dumped

### DIFF
--- a/library/src/components/Chat/components/ChatLineParser.tsx
+++ b/library/src/components/Chat/components/ChatLineParser.tsx
@@ -67,7 +67,10 @@ class ChatLineParser {
     if (highlights.length) {
       tokens.push({ token: ChatLineParser.HIGHLIGHT, expr: parseHighlight.createRegExp(highlights) });
     }
-    tokens.push({ token: ChatLineParser.NICK, expr: parseNicks.createRegExp() });
+    const nicks = parseNicks.createRegExp();
+    if (nicks) {
+      tokens.push({ token: ChatLineParser.NICK, expr: nicks });
+    }
 
     // Run through each parser
     const parser : ChatTextParser = new ChatTextParser(tokens);

--- a/library/src/components/Chat/components/ParseNicks.tsx
+++ b/library/src/components/Chat/components/ParseNicks.tsx
@@ -24,14 +24,17 @@ function fromText(text: string, keygen: () => number) : JSX.Element[] {
 function createRegExp() : RegExp {
   let regex: string;
   const chat: ChatSession = chatState.get('chat');
-  chat.getAllUsers().forEach((u: string) => {
-    if (!regex) {
-      regex = '\\b' + u + '\\b';
-    } else {
-      regex += '|\\b' + u + '\\b';
-    }
-  });
-  return new RegExp(regex, 'g');
+  const allUsers = chat.getAllUsers();
+  if (allUsers.length) {
+    allUsers.forEach((u: string) => {
+      if (!regex) {
+        regex = '\\b' + u + '\\b';
+      } else {
+        regex += '|\\b' + u + '\\b';
+      }
+    });
+    return new RegExp(regex, 'g');
+  }
 }
 
 export default {


### PR DESCRIPTION
Since the room member lists were disabled in chat, the nick parser has been triggering the brain fried core dumped warning because the RE generated started matching an empty string.

This PR recognises when there aren't any nicks to parse, and returns undefined, so when building up the parser tokens list we can chose to not add the nick parser.