### PR TITLE
Fix crafting input ownership + awesomeness

### DIFF
--- a/game/hud/src/widgets/Crafting/components/App.tsx
+++ b/game/hud/src/widgets/Crafting/components/App.tsx
@@ -5,6 +5,7 @@
  */
 
 import * as React from 'react';
+import * as _ from 'lodash';
 import { connect } from 'react-redux';
 import { client, jsKeyCodes, soundEvents } from '@csegames/camelot-unchained';
 import { craftingTimeToString } from '../services/util';
@@ -517,7 +518,8 @@ class App extends React.Component<AppProps, AppState> {
   }
 
   // Job properties
-  private setQuality = (quality: number) => {
+  /* tslint:disable:member-ordering */
+  private setQuality = _.debounce((quality: number) => {
     this.api(() => setVoxQuality(quality), 'Quality set to: ' + quality,
       () => {
         this.checkJobStatus();
@@ -525,9 +527,10 @@ class App extends React.Component<AppProps, AppState> {
       },
       () => setQuality(undefined),
     );
-  }
+  },600);
 
-  private setCount = (count: number) => {
+  /* tslint:disable:member-ordering */
+  private setCount = _.debounce((count: number) => {
     this.api(() => setVoxItemCount(count), 'Item Count set to: ' + count,
       () => {
         this.checkJobStatus();
@@ -535,7 +538,7 @@ class App extends React.Component<AppProps, AppState> {
       },
       () => setCount(undefined),
     );
-  }
+  },600);
 
   private setName = (name: string) => {
     this.api(() => setVoxName(name), 'Name set to: ' + name,

--- a/game/hud/src/widgets/Crafting/components/Button.tsx
+++ b/game/hud/src/widgets/Crafting/components/Button.tsx
@@ -22,7 +22,7 @@ export const Button = (props: ButtonProps) => {
   return (
     <button
       disabled={props.disabled}
-      className={css(ss.button)}
+      className={css(ss.button, props.disabled && ss.disabled)}
       onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
         if (!props.disableSound) {
           client.PlaySoundEvent(soundEvents.PLAY_UI_VOX_GENERICBUTTON);

--- a/game/hud/src/widgets/Crafting/components/Ingredients.tsx
+++ b/game/hud/src/widgets/Crafting/components/Ingredients.tsx
@@ -132,15 +132,17 @@ class Ingredients extends React.Component<IngredientsProps, IngredientsState> {
                 onSelect={this.select}
               />
               <span className={css(ss.times)}>x</span>
-              <Input
-                name='add-qty'
-                style={{ input: ingredientsStyles.quantity }}
-                numeric={true} min={1}
-                disabled={!qtyok}
-                onChange={this.onChange}
-                size={3}
-                value={this.state.qty.toString()}
-              />
+              <span style={ !qtyok ? { opacity: 0.3 } : {} }>
+                <Input
+                  name='add-qty'
+                  style={{ input: ingredientsStyles.quantity }}
+                  numeric={true} min={1}
+                  disabled={!qtyok}
+                  onChange={this.onChange}
+                  size={3}
+                  value={this.state.qty.toString()}
+                />
+              </span>
               <Button disabled={!ready} style={{ button: ingredientsStyles.add }} onClick={this.addIngredient}>Add</Button>
             </div>
           );

--- a/game/hud/src/widgets/Crafting/components/Input.tsx
+++ b/game/hud/src/widgets/Crafting/components/Input.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react';
-import { client } from '@csegames/camelot-unchained';
+import { client, jsKeyCodes } from '@csegames/camelot-unchained';
 import { StyleSheet, css, merge, input, InputStyles } from '../styles';
 
 interface InputProps {
@@ -33,7 +33,9 @@ class Input extends React.Component<InputProps, InputState> {
   }
 
   public componentWillReceiveProps(props: InputProps) {
-    this.setState({ changed: false, value: props.value });
+    if (props.value !== this.state.value) {
+      this.setState({ changed: false, value: props.value });
+    }
   }
 
   public render() {
@@ -58,7 +60,6 @@ class Input extends React.Component<InputProps, InputState> {
           onKeyUp={this.onKeyUp}
           onKeyDown={this.onKeyDown}
           onBlur={this.onBlur}
-          onClick={this.onClick}
           onFocus={this.onFocus}
           value={this.state.value}
           />
@@ -98,10 +99,6 @@ class Input extends React.Component<InputProps, InputState> {
     this.setState({ changed: true, value: e.target.value });
   }
 
-  private onClick = (e: React.MouseEvent<HTMLInputElement>) => {
-    client.RequestInputOwnership();
-  }
-
   private onFocus = (e: React.FocusEvent<HTMLInputElement>) => {
     client.RequestInputOwnership();
   }
@@ -115,15 +112,15 @@ class Input extends React.Component<InputProps, InputState> {
 
   private onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (this.props.numeric) {
-      if (e.keyCode > 47 && e.keyCode < 58) return;
-      if (e.keyCode === 8 || e.keyCode === 13) return;
+      if (e.keyCode >= jsKeyCodes.ZERO && e.keyCode <= jsKeyCodes.NINE) return;
+      if (e.keyCode === jsKeyCodes.BACKSPACE || e.keyCode === jsKeyCodes.ENTER) return;
       e.preventDefault();
     }
   }
 
   private onKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (this.state.changed) {
-      if (e.keyCode >= 32 || e.keyCode === 13) {
+      if (e.keyCode >= jsKeyCodes.SPACE || e.keyCode === jsKeyCodes.ENTER) {
         this.fireOnChange();
       }
     }

--- a/game/hud/src/widgets/Crafting/components/Input.tsx
+++ b/game/hud/src/widgets/Crafting/components/Input.tsx
@@ -38,6 +38,11 @@ class Input extends React.Component<InputProps, InputState> {
     }
   }
 
+  public componentWillUnmount() {
+    window.removeEventListener('mousedown', this.releaseOwnership);
+    client.ReleaseInputOwnership();
+  }
+
   public render() {
     const ss = StyleSheet.create(merge({}, input, this.props.style));
     let adjuster;
@@ -100,12 +105,23 @@ class Input extends React.Component<InputProps, InputState> {
   }
 
   private onFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (client.debug) console.log(`Input: on focus ${this.props.name} grab ownership`);
     client.RequestInputOwnership();
+    window.addEventListener('mousedown', this.releaseOwnership);
+  }
+
+  private releaseOwnership = (e: MouseEvent) => {
+    if (e.srcElement !== this.refs['input'] as HTMLInputElement) {
+      if (client.debug) console.log(`Input: mousedown elsewhere ${this.props.name} release ownership`);
+      client.ReleaseInputOwnership();
+      window.removeEventListener('mousedown', this.releaseOwnership);
+    }
   }
 
   private onBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    client.ReleaseInputOwnership();
+    if (client.debug) console.log(`Input: onBlur ${this.props.name}`);
     if (this.state.changed) {
+      if (client.debug) console.log(`Input: fireOnChange ${this.props.name}`);
       this.fireOnChange();
     }
   }

--- a/game/hud/src/widgets/Crafting/styles/index.ts
+++ b/game/hud/src/widgets/Crafting/styles/index.ts
@@ -106,7 +106,7 @@ export const input: InputStyles = {
   button: {
     cursor: 'pointer',
     height: '12px',
-    // fontSize: '10px',
+    fontSize: '10px',
     width: '8px',
     textAlign: 'center',
     lineHeight: '10px',

--- a/game/hud/src/widgets/Crafting/styles/index.ts
+++ b/game/hud/src/widgets/Crafting/styles/index.ts
@@ -14,6 +14,7 @@ import opts from './opts';
 
 export interface ButtonStyles {
   button: React.CSSProperties | any;
+  disabled: React.CSSProperties | any;
 }
 
 export const button: ButtonStyles = {
@@ -29,6 +30,12 @@ export const button: ButtonStyles = {
     border: '1px solid #1B263B',
     ':hover': {
       '-webkit-filter': 'brightness(1.2)',
+    },
+  },
+  disabled: {
+    color: '#444',
+    ':hover': {
+      '-webkit-filter': 'none',
     },
   },
 };


### PR DESCRIPTION
The main purpose of this PR is to fix an issue with input ownership if selecting the text of a quantity or quality field rather than clicking in it.  This is an annoyance for crafters and even a quit point for one.  https://forums.camelotunchained.com/topic/1184-crafting-ui-click-throughkeypress-issue/

Other fixes included in this PR are:

* Fixed font size for +/- buttons
* Make disabled buttons look and behave disabled.
* Make disabled ingredient quantity look disabled.
* Fix issue with changing quantity and clicking add too quickly

Removed `onchange` timeout from `Input` component and instead debounce the `setQuantity` and `setQuality` methods.  The timeout onChange was attempting to reduce the number of api calls made when changing quantity or quality, but it was also causing problems, for example, change ingredient quantity and quickly click add, and the pre-changed value would be added.

Debouncing the `setQuantity` and `setQuality` methods which make the api calls, is the correct way to deal with this and avoids the issue with the add button.

![image](https://user-images.githubusercontent.com/99895/43689113-40217d56-98ed-11e8-8460-6cb48483757d.png)
