### PR TITLE
Minor change to webpack sourcemap type

### DIFF
--- a/game/hud/webpack.config.js
+++ b/game/hud/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = function (e, rawArgv) {
 
   const config = {
     mode,
-    devtool: mode === 'development' ? 'eval-source-map' : 'source-map',
+    devtool: mode === 'development' ? 'source-map' : 'source-map',
     entry: {
       hud: ['./src/index.tsx'],
     },


### PR DESCRIPTION
This is a minor change to swap the webpack sourcemap type.

The current `eval-source-map` should work nicely in the browser for development, but does not work when in the client. I have swapped this to `source-map` to give solid support wherever the code is running.

This should make the `yarn start dev.webpack.hatchery` easier to debug with full source maps.