### PR TITLE
Fix clearing cooldown timer on action menu

### DIFF
--- a/game/hud/src/widgets/HUDFullScreen/components/Inventory/components/ContextMenu/ContextMenuAction.tsx
+++ b/game/hud/src/widgets/HUDFullScreen/components/Inventory/components/ContextMenu/ContextMenuAction.tsx
@@ -92,7 +92,7 @@ class ContextMenuAction extends React.Component<Props, State> {
   }
 
   public componentWillUnmount() {
-    clearTimeout(this.cooldownTimeout);
+    this.clearCooldownTimeout();
   }
 
   private handleQueryResult = (result: GraphQLResult<Pick<CUQuery, 'item'>>) => {
@@ -134,7 +134,7 @@ class ContextMenuAction extends React.Component<Props, State> {
   }
 
   private startCooldown = (lastTimePerformed: string) => {
-    this.cooldownTimeout = this.updateCooldownSeconds(lastTimePerformed);
+    this.updateCooldownSeconds(lastTimePerformed);
   }
 
   private updateCooldownSeconds = (lastTimePerformed: string) => {


### PR DESCRIPTION
There is an issue with the Inventory action menu cool down timer logic that results in the following warnings being issued by react

```Warning: Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.```

This PR fixes that issue by not clobbering cooldownTimeout as soon as it's set.