### PR TITLE
Throttle collection requests.

### DIFF
--- a/game/hud/src/components/Progression/index.tsx
+++ b/game/hud/src/components/Progression/index.tsx
@@ -215,13 +215,12 @@ class Progression extends React.Component<Props, State> {
 
   private onCollectClick = () => {
     this.setState({ collecting: true });
-    this.collectCharacterDayProgression(0);
+    this.collectCharacterDayProgression(0, this.state.logIDs);
+    this.onCloseClick();
   }
 
-  private collectCharacterDayProgression = async (logIDIndex: number) => {
+  private collectCharacterDayProgression = async (logIDIndex: number, logIDs: string[]) => {
     if (!this.state.logIDs[logIDIndex]) {
-      // set a timeout for the api server to update
-      this.setState({ collecting: false, collected: true });
       return;
     }
     try {
@@ -230,7 +229,7 @@ class Progression extends React.Component<Props, State> {
         client.loginToken,
         client.shardID,
         client.characterID,
-        this.state.logIDs[logIDIndex],
+        logIDs[logIDIndex],
       );
       if (!res.ok) {
         const resultData = typeof res.data === 'string' ? JSON.parse(res.data) : res.data;
@@ -240,7 +239,7 @@ class Progression extends React.Component<Props, State> {
       }
 
       // Recursively collect next days character progression
-      this.collectCharacterDayProgression(logIDIndex + 1);
+      setTimeout(() => this.collectCharacterDayProgression(logIDIndex + 1, logIDs), 500);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
There is an issue when trying to collect progression for any but a small number of days in that the client currently fires off requests for each day asynchronously, hammering the api server with 5, 10, 20, 30 simultaneous requests.  Invariably not all requests reach the server in the corrects order due to internetty things and / or concurrency issues happen while processing those requests simultaneously, which causes some of, many of the requests to fail with 'out of order' (trying to collect todays progression before collecting yesterdays).

To combat this, and to save the api server being hammered with requests, this PR changes the collection process to collect 1 day at a time, only collecting the next days progression after successfully collecting the current days progression, with an added 500ms delay so that at most 2 requests per second are fired at the server.

The progression dialog is closed immediately, and the collection process runs in background so the user is not left waiting for progression to download.

If a request fails, a toast dialog is shown as previously.

Tested collecting 32 days worth of progressions, which was initially (with old code) with a lot of out of order errors, with this change, all 32 days downloaded flawlessly over 16 seconds.