### PR TITLE
Fix clear keybind + fix rebind dialog styles

### DIFF
--- a/game/hud/src/widgets/Settings/components/Key.tsx
+++ b/game/hud/src/widgets/Settings/components/Key.tsx
@@ -9,9 +9,10 @@ import * as CSS from 'lib/css-helper';
 
 export const Key = styled('span')`
   display: flex;
-  align-items: center;
+  ${CSS.HORIZONTALLY_CENTERED}
   width: fit-content;
   height: fit-content;
+  box-sizing: border-box!important;
   background-color: rgb(7,7,7);
   background: radial-gradient(ellipse at center, rgba(12,12,12,1) 0%,rgba(7,7,7,1) 100%);
   text-align: center;

--- a/game/hud/src/widgets/Settings/panels/KeybindSettings/ClashModal.tsx
+++ b/game/hud/src/widgets/Settings/panels/KeybindSettings/ClashModal.tsx
@@ -7,6 +7,7 @@
 
 import * as React from 'react';
 import styled from 'react-emotion';
+import * as CSS from 'lib/css-helper';
 import { Binding } from '@csegames/camelot-unchained';
 import { Modal } from 'UI/Modal';
 import { Key } from '../../components/Key';
@@ -35,13 +36,14 @@ const Clashed = styled('div')`
 `;
 
 const ClashContent = styled('div')`
-  display: flex;
-  flex-direction: column;
+  ${CSS.IS_COLUMN} ${CSS.DONT_GROW}
+  ${CSS.HORIZONTALLY_CENTERED}
   min-height: 26px;
   margin-right: 5px;
   line-height: 26px;
   .clash-key {
     align-self: center;
+    pointer-events: none;
   }
 `;
 
@@ -73,8 +75,8 @@ class ClashModal extends React.Component<Props> {
               <Key className='clash-key'>{clash.boundKeyName}</Key> is already bound to
               <div>
                 {clash.sameAs.map((item: ClashKey, index: number) => (
-                  <span>
-                    <Bind key={index}>{spacify(item.name)}</Bind>
+                  <span key={index}>
+                    <Bind>{spacify(item.name)}</Bind>
                     {index !== clash.sameAs.length - 1 ? ', ' : ''}
                   </span>
                 ))}

--- a/game/hud/src/widgets/Settings/panels/KeybindSettings/index.tsx
+++ b/game/hud/src/widgets/Settings/panels/KeybindSettings/index.tsx
@@ -292,6 +292,7 @@ export class KeybindSettings extends React.PureComponent<KeybindSettingsProps, K
   private clearBind = (id: number, alias: number) => {
     this.dontListen();
     updateKeybind(getButtonNameFromId(id), { id, alias, boundKeyName: '', boundKeyValue: 0 });
+    client.ClearKeybind(id, alias);
     this.setState({ listening: null, version: this.state.version + 1, keybinds: getKeybinds() });
   }
 

--- a/game/hud/src/widgets/Settings/panels/KeybindSettings/index.tsx
+++ b/game/hud/src/widgets/Settings/panels/KeybindSettings/index.tsx
@@ -123,7 +123,7 @@ function sameBinds(keybinds: Keybinds, name: string, keybind: Binding): Clash | 
   Object.keys(keybinds).forEach((key) => {
     const binds = keybinds[key].boundKeys;
     for (let i = 0; i < binds.length; i++) {
-      if (binds[i].value === keybind.boundKeyValue && (name !== key || keybind.alias !== i)) {
+      if (binds[i].name === keybind.boundKeyName && (name !== key || keybind.alias !== i)) {
         sameAs.push({
           id: keybinds[key].button,
           name: key,


### PR DESCRIPTION
This PR does three things:

1. Fixes an issue where clearing a keybind isn't cleared, even if applied, until UI is reloaded.  The fix is to clear the keybind immediately, and is still persisted on apply.

2. Some style tweaks

3. Fixes the check for keybind clashes now compares keybind name instead of keybind value (affects binds that use modifier keys shift, alt and ctrl)