### PR TITLE
fix crafting css issues

### DIFF
--- a/game/hud/src/widgets/Crafting/components/App.tsx
+++ b/game/hud/src/widgets/Crafting/components/App.tsx
@@ -52,7 +52,7 @@ import Close from './Close';
 import Button from './Button';
 
 // Styles
-import { StyleSheet, css, merge, app, AppStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, app, AppStyles } from '../styles';
 
 const select = (state: GlobalState) => {
   return {
@@ -128,8 +128,8 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     return (
-      <div ref='crafting' className={'cu-window ' + css(ss.app)}>
-        <div className={css(ss.minimizedIcons)}>
+      <div ref='crafting' className={'cu-window ' + cssAphrodite(ss.app)}>
+        <div className={cssAphrodite(ss.minimizedIcons)}>
           <Close onClose={this.close}/>
           {/* <Minimize onMinimize={this.minimize} minimized={false}/> */}
         </div>
@@ -152,7 +152,7 @@ class App extends React.Component<AppProps, AppState> {
       case 'crafting':
         if (props.job.loading) {
           return (
-            <div className={css(ss.loading)}>
+            <div className={cssAphrodite(ss.loading)}>
               {/* Loading... */}
             </div>
           );
@@ -181,9 +181,9 @@ class App extends React.Component<AppProps, AppState> {
     // const type = props.job && props.job.type;
     const { status, outputItems } = props.job;
     return (
-      <div ref='crafting' className={'cu-window ' + css(ss.app, ss.minimized)}>
+      <div ref='crafting' className={'cu-window ' + cssAphrodite(ss.app, ss.minimized)}>
         {/* <VoxMessage/> */}
-        <div className={css(ss.minimizedIcons)}>
+        <div className={cssAphrodite(ss.minimizedIcons)}>
           <Close onClose={this.close}/>
           {/* <Minimize onMinimize={this.minimize} minimized={true}/> */}
         </div>

--- a/game/hud/src/widgets/Crafting/components/Button.tsx
+++ b/game/hud/src/widgets/Crafting/components/Button.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react';
 import { client, soundEvents } from '@csegames/camelot-unchained';
-import { StyleSheet, css, merge, button, ButtonStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, button, ButtonStyles } from '../styles';
 
 interface ButtonProps {
   disabled?: boolean;
@@ -22,7 +22,7 @@ export const Button = (props: ButtonProps) => {
   return (
     <button
       disabled={props.disabled}
-      className={css(ss.button, props.disabled && ss.disabled)}
+      className={cssAphrodite(ss.button, props.disabled && ss.disabled)}
       onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
         if (!props.disableSound) {
           client.PlaySoundEvent(soundEvents.PLAY_UI_VOX_GENERICBUTTON);

--- a/game/hud/src/widgets/Crafting/components/Close.tsx
+++ b/game/hud/src/widgets/Crafting/components/Close.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react';
-import { StyleSheet, css, merge, close, CloseStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, close, CloseStyles } from '../styles';
 
 interface CloseProps {
   onClose: () => void;
@@ -15,7 +15,7 @@ interface CloseProps {
 const Close = (props: CloseProps) => {
   const ss = StyleSheet.create(merge({}, close, props.style));
   return (
-    <span className={'cu-window-close ' + css(ss.close)} onClick={props.onClose}></span>
+    <span className={'cu-window-close ' + cssAphrodite(ss.close)} onClick={props.onClose}></span>
   );
 };
 

--- a/game/hud/src/widgets/Crafting/components/IngredientItem.tsx
+++ b/game/hud/src/widgets/Crafting/components/IngredientItem.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import { Ingredient } from '../services/types';
-import { StyleSheet, css, merge, ingredientItem, IngredientItemStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, ingredientItem, IngredientItemStyles } from '../styles';
 import Icon from './Icon';
 import { qualityToPercent, roundedMass } from '../services/util';
 
@@ -23,14 +23,14 @@ export const IngredientItem = (props: IngredientItemProps) => {
   // const pcnt = props.total && (props.qty / props.total * 100).toFixed(0);
   const slot = props.ingredient.slot && props.ingredient.slot.replace('Ingredient', '').replace('NonRecipe', '');
   return (
-    <div className={css(ss.ingredientItem)}>
-      <Icon className={css(ss.icon)} src={props.ingredient.static.icon}/>
-      <span className={css(ss.name)}>{name}</span>
-      <span className={css(ss.slot)}>{slot}</span>
-      <span className={css(ss.qty)}>{props.qty}</span>
-      {/* <span className={css(ss.pcnt)}></span> */}
-      <span className={css(ss.times)}>({Number(roundedMass(stats.weight).toFixed(3))}kg)</span>
-      <span className={css(ss.name)}>@ {stats ? qualityToPercent(stats.quality) | 0 : NaN}%</span>
+    <div className={cssAphrodite(ss.ingredientItem)}>
+      <Icon className={cssAphrodite(ss.icon)} src={props.ingredient.static.icon}/>
+      <span className={cssAphrodite(ss.name)}>{name}</span>
+      <span className={cssAphrodite(ss.slot)}>{slot}</span>
+      <span className={cssAphrodite(ss.qty)}>{props.qty}</span>
+      {/* <span className={cssAphrodite(ss.pcnt)}></span> */}
+      <span className={cssAphrodite(ss.times)}>({Number(roundedMass(stats.weight).toFixed(3))}kg)</span>
+      <span className={cssAphrodite(ss.name)}>@ {stats ? qualityToPercent(stats.quality) | 0 : NaN}%</span>
     </div>
   );
 };

--- a/game/hud/src/widgets/Crafting/components/Ingredients.tsx
+++ b/game/hud/src/widgets/Crafting/components/Ingredients.tsx
@@ -16,7 +16,7 @@ import PossibleIngredients from './PossibleIngredients';
 import PossibleSlots from './PossibleSlots';
 import Input from './Input';
 import Button from './Button';
-import { StyleSheet, css, merge, ingredients as ingredientsStyles, IngredientsStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, ingredients as ingredientsStyles, IngredientsStyles } from '../styles';
 
 export interface IngredientsPropsRedux {
   dispatch?: (action: any) => void;
@@ -99,7 +99,7 @@ class Ingredients extends React.Component<IngredientsProps, IngredientsState> {
       if (props.recipe) {
         // waiting for slots to load
         addIngredients = (
-          <div className={css(ss.addIngredient)}>
+          <div className={cssAphrodite(ss.addIngredient)}>
             {/* loading possible ingredients... */}
           </div>
         );
@@ -110,13 +110,13 @@ class Ingredients extends React.Component<IngredientsProps, IngredientsState> {
         if (props.selectedSlot) {
           // no ingredients, but slot selected, ingredients are being loaded
           possible = (
-            <div className={css(ss.message) + ' ingredients-searching'}>
+            <div className={cssAphrodite(ss.message) + ' ingredients-searching'}>
               {/* Searching bags for possible ingredients ... */}
             </div>
           );
         } else {
           possible = (
-            <div className={css(ss.message) + ' ingredients-pick-a-slot'}>
+            <div className={cssAphrodite(ss.message) + ' ingredients-pick-a-slot'}>
               { '<< pick a slot' }
             </div>
           );
@@ -124,14 +124,14 @@ class Ingredients extends React.Component<IngredientsProps, IngredientsState> {
       } else {
         if (props.possibleIngredients.length) {
           possible = (
-            <div className={css(ss.ingredient) + ' ingredients-select-ingredient'}>
+            <div className={cssAphrodite(ss.ingredient) + ' ingredients-select-ingredient'}>
               <PossibleIngredients
                 dispatch={this.props.dispatch}
                 disabled={!configuring}
                 selectedItem={selectedIngredient}
                 onSelect={this.select}
               />
-              <span className={css(ss.times)}>x</span>
+              <span className={cssAphrodite(ss.times)}>x</span>
               <span style={ !qtyok ? { opacity: 0.3 } : {} }>
                 <Input
                   name='add-qty'
@@ -151,9 +151,9 @@ class Ingredients extends React.Component<IngredientsProps, IngredientsState> {
         }
       }
       addIngredients = (
-        <div className={css(ss.addIngredientWrapper)}>
+        <div className={cssAphrodite(ss.addIngredientWrapper)}>
           <div>Select ingredients to load into Vox</div>
-          <div className={css(ss.addIngredient) + ' ingredients-add'}>
+          <div className={cssAphrodite(ss.addIngredient) + ' ingredients-add'}>
             <PossibleSlots
               dispatch={this.props.dispatch}
               disabled={!configuring}
@@ -167,9 +167,9 @@ class Ingredients extends React.Component<IngredientsProps, IngredientsState> {
     }
 
     return (
-      <div className={css(ss.ingredients) + ' ingredients'}>
+      <div className={cssAphrodite(ss.ingredients) + ' ingredients'}>
         {addIngredients}
-        <div className={css(ss.loadedIngredients) + ' ingreadients-already-loaded'}>
+        <div className={cssAphrodite(ss.loadedIngredients) + ' ingreadients-already-loaded'}>
           <div>Loaded Ingredients</div>
           <div>{loaded}</div>
           { last

--- a/game/hud/src/widgets/Crafting/components/Input.tsx
+++ b/game/hud/src/widgets/Crafting/components/Input.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import { client, jsKeyCodes } from '@csegames/camelot-unchained';
-import { StyleSheet, css, merge, input, InputStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, input, InputStyles } from '../styles';
 
 interface InputProps {
   name?: string;      // temp for debugging
@@ -48,17 +48,17 @@ class Input extends React.Component<InputProps, InputState> {
     let adjuster;
     if (this.props.numeric) {
       adjuster = (
-        <div className={css(ss.adjuster)}>
-          <div className={css(ss.button)} onClick={this.increment}>+</div>
-          <div className={css(ss.button)} onClick={this.decrement}>-</div>
+        <div className={cssAphrodite(ss.adjuster)}>
+          <div className={cssAphrodite(ss.button)} onClick={this.increment}>+</div>
+          <div className={cssAphrodite(ss.button)} onClick={this.decrement}>-</div>
         </div>
       );
     }
     return (
-      <div className={css(ss.input)}>
+      <div className={cssAphrodite(ss.input)}>
         <input type='text'
           ref='input'
-          className={css(ss.field)}
+          className={cssAphrodite(ss.field)}
           size={this.props.size}
           disabled={this.props.disabled}
           onChange={this.onChange}

--- a/game/hud/src/widgets/Crafting/components/JobDetails.tsx
+++ b/game/hud/src/widgets/Crafting/components/JobDetails.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { GlobalState } from '../services/session/reducer';
 import { Ingredient, Recipe, InventoryItem } from '../services/types';
-import { StyleSheet, css, merge, jobDetails, JobDetailsStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, jobDetails, JobDetailsStyles } from '../styles';
 import Ingredients from './Ingredients';
 
 import Button from './Button';
@@ -68,20 +68,20 @@ export const JobDetails = (props: JobDetailsProps) => {
   // If no vox type set yet...
   if (!type || type === 'invalid') {
     return (
-      <div className={css(ss.jobDetails)}>
-        <div className={css(ss.ingredients) + ' job-details-ingredients'}>Select a job above</div>
+      <div className={cssAphrodite(ss.jobDetails)}>
+        <div className={cssAphrodite(ss.ingredients) + ' job-details-ingredients'}>Select a job above</div>
         <VoxMessage/>
       </div>
     );
   }
 
   return (
-    <div className={css(ss.jobDetails) + ' job-details'}>
-      <div className={css(ss.properties) + ' job-details-properties'}>
+    <div className={cssAphrodite(ss.jobDetails) + ' job-details'}>
+      <div className={cssAphrodite(ss.properties) + ' job-details-properties'}>
         {type === 'make' && <NameInput onChange={props.setName}/>}
         <RecipeSelect dispatch={props.dispatch} onSelect={props.setRecipe}/>
       </div>
-      <div className={css(ss.buttons) + ' job-details-footer'}>
+      <div className={cssAphrodite(ss.buttons) + ' job-details-footer'}>
         <QualityInput disabled={!canQuality} onChange={props.setQuality}/>
         <QuantityInput disabled={!canQuantity} onChange={props.setCount}/>
         <div>
@@ -90,7 +90,7 @@ export const JobDetails = (props: JobDetailsProps) => {
           <Button style={buttonStyle} disabled={!canCancel} onClick={props.cancel}>Cancel</Button>
         </div>
       </div>
-      <div className={css(ss.ingredients) + ' job-details-ingredients'}>
+      <div className={cssAphrodite(ss.ingredients) + ' job-details-ingredients'}>
         <Ingredients
           add={props.addIngredient}
           remove={props.removeIngredient}

--- a/game/hud/src/widgets/Crafting/components/JobType.tsx
+++ b/game/hud/src/widgets/Crafting/components/JobType.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { StyleSheet, css, merge, jobType, JobTypeStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, jobType, JobTypeStyles } from '../styles';
 import { GlobalState } from '../services/session/reducer';
 
 import Button from './Button';
@@ -61,7 +61,7 @@ export const JobType = (props: JobTypeProps) => {
   switch (props.mode) {
     case 'crafting':
       craftingButtons = (
-        <div className={css(ss.jobButtons)}>
+        <div className={cssAphrodite(ss.jobButtons)}>
           {button('purify')}
           {button('grind')}
           {button('shape')}
@@ -77,7 +77,7 @@ export const JobType = (props: JobTypeProps) => {
       );
   }
   return (
-    <div className={css(ss.jobType)}>
+    <div className={cssAphrodite(ss.jobType)}>
       {craftingButtons}
       { props.mode === 'crafting'
         ? <Button style={{ button: jobType.tools }} onClick={props.toggle}>Tools &gt;</Button>

--- a/game/hud/src/widgets/Crafting/components/Label.tsx
+++ b/game/hud/src/widgets/Crafting/components/Label.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react';
-import { StyleSheet, css, merge, labelStyles, LabelStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, labelStyles, LabelStyles } from '../styles';
 
 interface LabelProps {
   children?: any;
@@ -15,7 +15,7 @@ interface LabelProps {
 const Label = (props: LabelProps) => {
   const ss = StyleSheet.create(merge({}, labelStyles, props.style));
   return (
-    <span className={css(ss.label)}>{props.children}:</span>
+    <span className={cssAphrodite(ss.label)}>{props.children}:</span>
   );
 };
 

--- a/game/hud/src/widgets/Crafting/components/Minimize.tsx
+++ b/game/hud/src/widgets/Crafting/components/Minimize.tsx
@@ -6,7 +6,7 @@
 
 
 import * as React from 'react';
-import { StyleSheet, css, merge, minimize, MinimizeStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, minimize, MinimizeStyles } from '../styles';
 
 interface MinimizeProps {
   onMinimize: () => void;
@@ -18,7 +18,7 @@ const Minimize = (props: MinimizeProps) => {
   const ss = StyleSheet.create(merge({}, minimize, props.style));
   return (
     <span
-      className={css(ss.minimize, props.minimized ? ss.maximized : ss.minimized)}
+      className={cssAphrodite(ss.minimize, props.minimized ? ss.maximized : ss.minimized)}
       onClick={props.onMinimize}/>
   );
 };

--- a/game/hud/src/widgets/Crafting/components/NameInput.tsx
+++ b/game/hud/src/widgets/Crafting/components/NameInput.tsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import Label from './Label';
 import Input from './Input';
 import { GlobalState } from '../services/session/reducer';
-import { StyleSheet, css, merge, nameInput, NameInputStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, nameInput, NameInputStyles } from '../styles';
 
 export interface NameInputReduxProps {
   dispatch?: (action: any) => void;
@@ -30,7 +30,7 @@ const select = (state: GlobalState, props: NameInputProps): NameInputReduxProps 
 const NameInput = (props: NameInputProps) => {
   const ss = StyleSheet.create(merge({}, nameInput, props.style));
   return (
-    <div className={css(ss.nameInput)}>
+    <div className={cssAphrodite(ss.nameInput)}>
       <Label style={{ label: nameInput.label }}>Name</Label>
       <Input size={32} onChange={props.onChange} value={props.name}/>
     </div>

--- a/game/hud/src/widgets/Crafting/components/OutputItems.tsx
+++ b/game/hud/src/widgets/Crafting/components/OutputItems.tsx
@@ -11,7 +11,7 @@ import { InventoryItem } from '../services/types';
 import { craftingTimeToString, qualityToPercent, roundedMass } from '../services/util';
 import Icon from './Icon';
 
-import { StyleSheet, css, merge, outputItems, OutputItemsStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, outputItems, OutputItemsStyles } from '../styles';
 
 export interface OutputItemsReduxProps {
   dispatch?: (action: any) => void;
@@ -33,24 +33,24 @@ const OutputItems = (props: OutputItemsProps) => {
   if (!props.outputItems || !props.outputItems.length) return null;
   const ss = StyleSheet.create(merge({}, outputItems, props.style));
   return (
-    <div className={css(ss.outputItems)}>
-      <div className={css(ss.title)}>
+    <div className={cssAphrodite(ss.outputItems)}>
+      <div className={cssAphrodite(ss.title)}>
         <span>Output Info:</span>
-        <span className={css(ss.craftingTime)}>
+        <span className={cssAphrodite(ss.craftingTime)}>
           Crafting Time: {craftingTimeToString(props.totalCraftingTime, true)}
         </span>
       </div>
       {
         props.outputItems.map((item: InventoryItem) => {
           return (
-            <div key={item.id} className={css(ss.item)}>
-              <Icon className={css(ss.icon)} src={item.static.icon}/>
-              <span className={css(ss.name)}>{item.name}</span>
-              <span className={css(ss.qty)}>{item.stats.unitCount}</span>
-              <span className={css(ss.times)}>
+            <div key={item.id} className={cssAphrodite(ss.item)}>
+              <Icon className={cssAphrodite(ss.icon)} src={item.static.icon}/>
+              <span className={cssAphrodite(ss.name)}>{item.name}</span>
+              <span className={cssAphrodite(ss.qty)}>{item.stats.unitCount}</span>
+              <span className={cssAphrodite(ss.times)}>
                 ({Number(roundedMass(item.stats.weight).toFixed(3))}kg)
               </span>
-              <span className={css(ss.name)}>
+              <span className={cssAphrodite(ss.name)}>
                 @ {qualityToPercent(item.stats.quality) | 0}%
               </span>
             </div>

--- a/game/hud/src/widgets/Crafting/components/PossibleIngredients.tsx
+++ b/game/hud/src/widgets/Crafting/components/PossibleIngredients.tsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { GlobalState } from '../services/session/reducer';
 import Select from './Select';
 import { Ingredient, InventoryItem } from '../services/types';
-import { StyleSheet, css, merge, possibleIngredients, PossibleIngredientsStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, possibleIngredients, PossibleIngredientsStyles } from '../styles';
 import Icon from './Icon';
 import { qualityToPercent, roundedMass } from '../services/util';
 
@@ -43,15 +43,17 @@ export class PossibleIngredients extends React.Component<PossibleIngredientsProp
     const ss = StyleSheet.create(merge({}, possibleIngredients, this.props.style));
     const isRepair = this.props.jobType === 'repair';
     const render = (item: InventoryItem) => item && (
-      <div className={css(ss.possibleIngredients)}>
-        <Icon className={css(ss.span, ss.icon)} src={item.static.icon}/>
-        <span className={css(ss.span, ss.name)}>{item.name}</span>
-        { isRepair || <span className={css(ss.span, ss.quantity)}>x{item.stats.unitCount}</span> }
-        { isRepair || <span className={css(ss.span, ss.quality)}>@ {qualityToPercent(item.stats.quality) | 0}%</span> }
-        { isRepair || <span className={css(ss.span, ss.weight)}>
+      <div className={cssAphrodite(ss.possibleIngredients)}>
+        <Icon className={cssAphrodite(ss.span, ss.icon)} src={item.static.icon}/>
+        <span className={cssAphrodite(ss.span, ss.name)}>{item.name}</span>
+        { isRepair || <span className={cssAphrodite(ss.span, ss.quantity)}>x{item.stats.unitCount}</span> }
+        { isRepair || <span className={cssAphrodite(ss.span, ss.quality)}>
+          @ {qualityToPercent(item.stats.quality) | 0}%
+        </span> }
+        { isRepair || <span className={cssAphrodite(ss.span, ss.weight)}>
           {Number(roundedMass(item.stats.weight).toFixed(3))}kg</span> }
-        { isRepair && <span className={css(ss.span, ss.durability)}>{item.stats.durability.current} dur</span> }
-        { isRepair && <span className={css(ss.span, ss.points)}>{item.stats.durability.currentPoints} pts</span> }
+        { isRepair && <span className={cssAphrodite(ss.span, ss.durability)}>{item.stats.durability.current} dur</span> }
+        { isRepair && <span className={cssAphrodite(ss.span, ss.points)}>{item.stats.durability.currentPoints} pts</span> }
       </div>
     );
     return (

--- a/game/hud/src/widgets/Crafting/components/PossibleSlots.tsx
+++ b/game/hud/src/widgets/Crafting/components/PossibleSlots.tsx
@@ -13,7 +13,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { GlobalState } from '../services/session/reducer';
 import Select from './Select';
-import { StyleSheet, css, merge, possibleSlots, PossibleSlotsStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, possibleSlots, PossibleSlotsStyles } from '../styles';
 
 interface PossibleSlotsReduxProps {
   possibleItemSlots?: string[];
@@ -41,7 +41,7 @@ export class PossibleSlots extends React.Component<PossibleSlotsProps, PossibleS
   public render() {
     const ss = StyleSheet.create(merge({}, possibleSlots, this.props.style));
     const render = (slot: string) => slot && (
-      <div className={css(ss.possibleSlots)}>
+      <div className={cssAphrodite(ss.possibleSlots)}>
         {slot && slot.replace('NonRecipe', 'Any')}
       </div>
     );

--- a/game/hud/src/widgets/Crafting/components/ProgressBar.tsx
+++ b/game/hud/src/widgets/Crafting/components/ProgressBar.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react';
-import { StyleSheet, css, merge, progressBar, ProgressBarStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, progressBar, ProgressBarStyles } from '../styles';
 
 interface ProgressBarProps {
   total: number;
@@ -17,7 +17,7 @@ interface ProgressBarProps {
 
 const ProgressBar = (props: ProgressBarProps) => {
   const ss = StyleSheet.create(merge({}, progressBar, props.style));
-  return <div className={css(ss.progressBar)} style={{
+  return <div className={cssAphrodite(ss.progressBar)} style={{
     width: (100 - (props.current / props.total * 100)).toFixed(2) + '%',
     backgroundColor: props.color,
   }}/>;

--- a/game/hud/src/widgets/Crafting/components/QualityInput.tsx
+++ b/game/hud/src/widgets/Crafting/components/QualityInput.tsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import Label from './Label';
 import Input from './Input';
 import { GlobalState } from '../services/session/reducer';
-import { StyleSheet, css, merge, qualityInput, QualityInputStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, qualityInput, QualityInputStyles } from '../styles';
 
 export interface QualityInputReduxProps {
   dispatch?: (action: any) => void;
@@ -31,7 +31,7 @@ const select = (state: GlobalState, props: QualityInputProps): QualityInputRedux
 const QualityInput = (props: QualityInputProps) => {
   const ss = StyleSheet.create(merge({}, qualityInput, props.style));
   return (
-    <div className={css(ss.qualityInput)} style={ props.disabled ? { opacity: 0.3 } : {} }>
+    <div className={cssAphrodite(ss.qualityInput)} style={ props.disabled ? { opacity: 0.3 } : {} }>
       <Label style={{ label: qualityInput.label }}>Quality</Label>
       <Input
         name='quality'

--- a/game/hud/src/widgets/Crafting/components/QuantityInput.tsx
+++ b/game/hud/src/widgets/Crafting/components/QuantityInput.tsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import Label from './Label';
 import Input from './Input';
 import { GlobalState } from '../services/session/reducer';
-import { StyleSheet, css, merge, quantityInput } from '../styles';
+import { StyleSheet, cssAphrodite, merge, quantityInput } from '../styles';
 
 export interface QuantityInputReduxProps {
   dispatch?: (action: any) => void;
@@ -34,7 +34,7 @@ const select = (state: GlobalState, props: QuantityInputProps): QuantityInputRed
 const QuantityInput = (props: QuantityInputProps) => {
   const ss = StyleSheet.create(merge({}, quantityInput, props.style));
   return (
-    <div className={css(ss.quantityInput)} style={ props.disabled ? { opacity: 0.3 } : {} }>
+    <div className={cssAphrodite(ss.quantityInput)} style={ props.disabled ? { opacity: 0.3 } : {} }>
       <Label style={{ label: quantityInput.label }}>Quantity</Label>
       <Input
         name='quantity'

--- a/game/hud/src/widgets/Crafting/components/RecipeSelect.tsx
+++ b/game/hud/src/widgets/Crafting/components/RecipeSelect.tsx
@@ -10,7 +10,7 @@ import Select from './Select';
 import Label from './Label';
 import { GlobalState } from '../services/session/reducer';
 import { Recipe } from '../services/types';
-import { StyleSheet, css, merge, recipeSelect, RecipeSelectStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, recipeSelect, RecipeSelectStyles } from '../styles';
 
 export interface RecipeSelectReduxProps {
   type?: string;
@@ -49,7 +49,7 @@ class RecipeSelect extends React.Component<RecipeSelectProps, RecipeSelectState>
     const selectedItem = i > -1 ? this.props.items[i] : null;
     // const type = this.props.type;
     return (
-      <div className={css(ss.recipeSelect)}>
+      <div className={cssAphrodite(ss.recipeSelect)}>
         <Label style={{ label: recipeSelect.label }}>
           Select Desired Output
           {/* {type[0].toUpperCase() + type.substr(1)} Recipe */}

--- a/game/hud/src/widgets/Crafting/components/RepairItem.tsx
+++ b/game/hud/src/widgets/Crafting/components/RepairItem.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import { Ingredient } from '../services/types';
-import { StyleSheet, css, merge, repairItem, RepairItemStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, repairItem, RepairItemStyles } from '../styles';
 import Icon from './Icon';
 
 export interface RepairItemProps {
@@ -18,11 +18,11 @@ export const RepairItem = (props: RepairItemProps) => {
   const ss = StyleSheet.create(merge({}, repairItem, props.style));
   const { name, stats } = props.ingredient;
   return (
-    <div className={css(ss.repairItem)}>
-      <Icon className={css(ss.icon)} src={props.ingredient.static.icon}/>
-      <span className={css(ss.name)}>{name}</span>
-      <span className={css(ss.durability)}>Durability: {stats.durability.current}</span>
-      <span className={css(ss.points)}>Cost: {stats.durability.currentPoints}</span>
+    <div className={cssAphrodite(ss.repairItem)}>
+      <Icon className={cssAphrodite(ss.icon)} src={props.ingredient.static.icon}/>
+      <span className={cssAphrodite(ss.name)}>{name}</span>
+      <span className={cssAphrodite(ss.durability)}>Durability: {stats.durability.current}</span>
+      <span className={cssAphrodite(ss.points)}>Cost: {stats.durability.currentPoints}</span>
     </div>
   );
 };

--- a/game/hud/src/widgets/Crafting/components/Select.tsx
+++ b/game/hud/src/widgets/Crafting/components/Select.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import { client, soundEvents } from '@csegames/camelot-unchained';
-import { StyleSheet, css, merge, select, SelectStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, select, SelectStyles } from '../styles';
 
 export interface SelectProps {
   items: any[];
@@ -40,12 +40,12 @@ class Select extends React.Component<SelectProps, SelectState> {
     if (this.props.items.length === 0) {
       // No items to display
       return (
-        <div className={css(ss.select)}>
-          <div className={css(ss.impl)}>
-            <div className={css(ss.active)}>
+        <div className={cssAphrodite(ss.select)}>
+          <div className={cssAphrodite(ss.impl)}>
+            <div className={cssAphrodite(ss.active)}>
               {this.props.renderActiveItem(null)}
             </div>
-            <div className={css(ss.arrow)} style={{ opacity: 0.5 }}>
+            <div className={cssAphrodite(ss.arrow)} style={{ opacity: 0.5 }}>
               <i className='fa fa-chevron-down' aria-hidden='true'></i>
             </div>
           </div>
@@ -55,18 +55,18 @@ class Select extends React.Component<SelectProps, SelectState> {
     // if selectedItem is undefined or null, we get -1 which is exactly what we want
     const selectedIndex = this.props.items.indexOf(this.props.selectedItem);
     return(
-      <div className={css(ss.select)}>
-        <div className={css(ss.impl)} style={this.state.showList ? { zIndex: 1000 } : {}}>
+      <div className={cssAphrodite(ss.select)}>
+        <div className={cssAphrodite(ss.impl)} style={this.state.showList ? { zIndex: 1000 } : {}}>
           <div
-            className={this.state.showList ? css(ss.outside) : css(ss.outside, ss.outsideHidden)}
+            className={this.state.showList ? cssAphrodite(ss.outside) : cssAphrodite(ss.outside, ss.outsideHidden)}
             onClick={(e) => { this.onClick(e, false); }} />
-          <div className={css(ss.active)} onClick={(e) => { this.onClick(e, !this.state.showList); }}>
+          <div className={cssAphrodite(ss.active)} onClick={(e) => { this.onClick(e, !this.state.showList); }}>
             {this.props.renderActiveItem(this.props.items[selectedIndex])}
           </div>
-          <div className={css(ss.arrow)} onClick={(e) => { this.onClick(e, !this.state.showList); }}>
+          <div className={cssAphrodite(ss.arrow)} onClick={(e) => { this.onClick(e, !this.state.showList); }}>
             <i className={`fa ${this.state.showList ? 'fa-chevron-up' : 'fa-chevron-down'}`} aria-hidden='true'></i>
           </div>
-          <div className={this.state.showList ? css(ss.list) : css(ss.list, ss.listHidden)}>
+          <div className={this.state.showList ? cssAphrodite(ss.list) : cssAphrodite(ss.list, ss.listHidden)}>
             {this.props.items.map(this.buildListItem)}
           </div>
         </div>
@@ -103,7 +103,7 @@ class Select extends React.Component<SelectProps, SelectState> {
       <div
         key={itemIndex}
         onClick={this.onItemSelect.bind(this, item, itemIndex)}
-        className={isSelectedItem ? css(ss.listItem, ss.listItemSelected) : css(ss.listItem)}>
+        className={isSelectedItem ? cssAphrodite(ss.listItem, ss.listItemSelected) : cssAphrodite(ss.listItem)}>
         {this.props.renderListItem(item)}
       </div>
     );

--- a/game/hud/src/widgets/Crafting/components/Tools.tsx
+++ b/game/hud/src/widgets/Crafting/components/Tools.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import { connect, DispatchProp } from 'react-redux';
-import { StyleSheet, css, merge, tools, ToolsStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, tools, ToolsStyles } from '../styles';
 
 // Helpers
 import { slash } from '../services/game/slash';
@@ -80,9 +80,9 @@ class Tools extends React.Component<ToolsProps, ToolsState> {
     };
 
     return (
-      <div className={css(ss.tools)}>
-        <div className={css(ss.section)}>
-          <h1 className={css(ss.sectionHeading)}>Resources</h1>
+      <div className={cssAphrodite(ss.tools)}>
+        <div className={cssAphrodite(ss.section)}>
+          <h1 className={cssAphrodite(ss.sectionHeading)}>Resources</h1>
 
           <div>
             { makeButton({
@@ -97,8 +97,8 @@ class Tools extends React.Component<ToolsProps, ToolsState> {
           </div>
         </div>
 
-        <div className={css(ss.section)}>
-          <h1 className={css(ss.sectionHeading)}>Admin Commands</h1>
+        <div className={cssAphrodite(ss.section)}>
+          <h1 className={cssAphrodite(ss.sectionHeading)}>Admin Commands</h1>
 
           <div>
             { makeButton({

--- a/game/hud/src/widgets/Crafting/components/VoxInfo.tsx
+++ b/game/hud/src/widgets/Crafting/components/VoxInfo.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { GlobalState, JobState } from '../services/session/reducer';
 
-import { StyleSheet, css, merge, voxInfo, VoxInfoStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, voxInfo, VoxInfoStyles } from '../styles';
 
 export interface VoxInfoReduxProps {
   dispatch?: (action: any) => void;
@@ -28,15 +28,15 @@ const select = (state: GlobalState, props: VoxInfoProps): VoxInfoReduxProps => {
 const VoxInfo = (props: VoxInfoProps) => {
   const ss = StyleSheet.create(merge({}, voxInfo, props.style));
   return (
-    <div className={css(ss.voxInfo)}>
-      <span className={css(ss.span)}>{props.job.status}</span>
-      <span className={css(ss.span)}>{props.job.type}</span>
-      <span className={css(ss.span)}>{props.job.started}</span>
-      <span className={css(ss.span)}>{props.job.totalCraftingTime}</span>
-      <span className={css(ss.span)}>{props.job.recipe && props.job.recipe.id}</span>
-      <span className={css(ss.span)}>{props.job.name}</span>
-      <span className={css(ss.span)}>{props.job.quality}</span>
-      <span className={css(ss.span)}>{props.job.itemCount}</span>
+    <div className={cssAphrodite(ss.voxInfo)}>
+      <span className={cssAphrodite(ss.span)}>{props.job.status}</span>
+      <span className={cssAphrodite(ss.span)}>{props.job.type}</span>
+      <span className={cssAphrodite(ss.span)}>{props.job.started}</span>
+      <span className={cssAphrodite(ss.span)}>{props.job.totalCraftingTime}</span>
+      <span className={cssAphrodite(ss.span)}>{props.job.recipe && props.job.recipe.id}</span>
+      <span className={cssAphrodite(ss.span)}>{props.job.name}</span>
+      <span className={cssAphrodite(ss.span)}>{props.job.quality}</span>
+      <span className={cssAphrodite(ss.span)}>{props.job.itemCount}</span>
     </div>
   );
 };

--- a/game/hud/src/widgets/Crafting/components/VoxMessage.tsx
+++ b/game/hud/src/widgets/Crafting/components/VoxMessage.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { StyleSheet, css, merge, voxMessage, VoxMessageStyles } from '../styles';
+import { StyleSheet, cssAphrodite, merge, voxMessage, VoxMessageStyles } from '../styles';
 import { GlobalState } from '../services/session/reducer';
 import { Message } from '../services/types';
 import ProgressBar from './ProgressBar';
@@ -35,7 +35,7 @@ const VoxMessage = (props: VoxMessageProps) => {
   const ss = StyleSheet.create(merge({}, voxMessage, props.style));
   const { message, total, remaining, status } = props;
   return (
-    <div className={(message ? css(ss.voxMessage, ss[message.type]) : css(ss.voxMessage))}>
+    <div className={(message ? cssAphrodite(ss.voxMessage, ss[message.type]) : cssAphrodite(ss.voxMessage))}>
       <div>{message && message.message}</div>
       { status === 'Running'
         ? <ProgressBar

--- a/game/hud/src/widgets/Crafting/styles/index.ts
+++ b/game/hud/src/widgets/Crafting/styles/index.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-export { StyleSheet, css } from 'aphrodite';
+export { StyleSheet, css as cssAphrodite } from 'aphrodite';
 export { merge } from 'lodash';
 import opts from './opts';
 


### PR DESCRIPTION
There are lots of issues with crafting and `css()` from `aphrodite` clashing with the `react-emotion` babel plugin which looks for `css()` from `emotion`.

This renames all occurrences of `css()` to `cssAphrodite()` to remove the issue.