### PR TITLE
HUD Editor Tweaks

### DIFF
--- a/game/hud/src/components/HUD/HUDEditor.tsx
+++ b/game/hud/src/components/HUD/HUDEditor.tsx
@@ -85,7 +85,6 @@ class HUDEditor extends React.Component<Props, State> {
     const { widgets } = this.props;
     return (
       <HUDEditorContainer
-        className='cse-ui-scroller-thumbonly'
         style={{
           right: `${this.state.editorPosition.x}px`,
           top: `${this.state.editorPosition.y}px`,
@@ -98,7 +97,7 @@ class HUDEditor extends React.Component<Props, State> {
             </a>
           </div>
         </HUDEditorTitle>
-        <HUDEditorList>
+        <HUDEditorList className='cse-ui-scroller-thumbonly'>
           <ul>
             { _.sortBy(widgets, 'name').map((widget) => {
               return (widget.name === 'building' ? null : // building should be removed as HUDDrag item

--- a/game/hud/src/components/HUD/HUDEditor.tsx
+++ b/game/hud/src/components/HUD/HUDEditor.tsx
@@ -74,7 +74,7 @@ class HUDEditor extends React.Component<Props, State> {
     super(props);
     this.state = {
       mode: EditMode.NONE,
-      editorPosition: { x: 2, y: 300 },
+      editorPosition: { x: 35, y: 150 },
       minScale: 0.5,
       maxScale: 3,
       scaleFactor: 0.01,
@@ -112,6 +112,13 @@ class HUDEditor extends React.Component<Props, State> {
                       'HUDWidgetNameSelected' : 'HUDWidgetName'
                   }>
                     { widget.name === 'motd' ? 'MOTD' : _.startCase(widget.name) }
+                    { !widget.widget.position.visibility &&
+                      <span>&nbsp;<i
+                        className={'fa fa-eye-slash'}
+                        onMouseOver={ this.onMouseOverListVisibility }
+                        onMouseLeave={ this.onMouseLeave }
+                      ></i></span>
+                    }
                   </div>
                 </li>
               );
@@ -425,6 +432,12 @@ class HUDEditor extends React.Component<Props, State> {
         layoutMode: widget.position.layoutMode,
       },
     }));
+  }
+
+  private onMouseOverListVisibility = (e: React.MouseEvent<HTMLElement>) => {
+    this.tooltipMessage = 'Widget is Hidden';
+    this.tooltipEvent = e;
+    this.onMouseOver(e);
   }
 
   private onMouseOverToggleVisibility = (e: React.MouseEvent<HTMLElement>) => {

--- a/game/hud/src/services/session/layout.ts
+++ b/game/hud/src/services/session/layout.ts
@@ -311,6 +311,7 @@ export function initialize() {
         case 'chat':
           return dispatch(toggleVisibility(name));
         case 'ui': return dispatch(toggleHUDLock(addEvent, removeEvent));
+        case 'lockui': return dispatch(lockHUD(removeEvent));
         case 'reset': return dispatch(resetHUD());
         default: return;
       }

--- a/game/hud/src/services/session/layoutItems/HUDNav.tsx
+++ b/game/hud/src/services/session/layoutItems/HUDNav.tsx
@@ -20,6 +20,7 @@ const hideClientControlledUI = () => {
   client.HideUI('inventory');
   client.HideUI('equippedgear');
   client.HideUI('plotcontrol');
+  events.fire('hudnav--navigate', 'lockui');
 };
 
 export default {
@@ -122,6 +123,7 @@ export default {
         onClick: () => {
           events.fire('hudnav--navigate', 'equippedgear-left');
           events.fire('hudnav--navigate', 'inventory-right');
+          hideClientControlledUI();
         },
       },
       {
@@ -137,6 +139,7 @@ export default {
         onClick: () => {
           events.fire('hudnav--navigate', 'equippedgear-left');
           events.fire('hudnav--navigate', 'inventory-right');
+          hideClientControlledUI();
         },
       },
       // {

--- a/game/hud/src/services/session/layoutItems/HUDNav.tsx
+++ b/game/hud/src/services/session/layoutItems/HUDNav.tsx
@@ -339,20 +339,20 @@ export default {
           events.fire('hudnav--navigate', 'ui');
         },
       },
-      {
-        name: 'reset',
-        tooltip: 'Reset UI layout',
-        iconClass: 'fa-clone',
-        icon: (
-          <span>
-            <i className='fa fa-clone fa-stack-1x fa-inverse'></i>
-          </span>
-        ),
-        hidden: false,
-        onClick: () => {
-          events.fire('hudnav--navigate', 'reset');
-        },
-      },
+      // {
+      //   name: 'reset',
+      //   tooltip: 'Reset UI layout',
+      //   iconClass: 'fa-clone',
+      //   icon: (
+      //     <span>
+      //       <i className='fa fa-clone fa-stack-1x fa-inverse'></i>
+      //     </span>
+      //   ),
+      //   hidden: false,
+      //   onClick: () => {
+      //     events.fire('hudnav--navigate', 'reset');
+      //   },
+      // },
       {
         name: 'reloadui',
         tooltip: 'Reload UI',


### PR DESCRIPTION
I have more work to do on the HUD editor, based on prior feedback from JB. However, this fixes a couple of the more obvious small issues:

- Changes default HUD Editor position, to a location where the Bug Report button doesn't overlap the scrollbar.
- Fixes the scrollbar not using the 'pretty' decorations.
- Shows an icon in the HUD Editor list, if a widget is hidden (this will be improved, based on feedback from Mehuge and JB).
- Remove UI Reset button from HUDNav (since it is now in HUD Editor).
- Lock UI if any of the fullscreen UI's are opened.