### PR TITLE
Scoreboard / SearchableList improvements

### DIFF
--- a/game/hud/src/components/ScenarioResults/components/ScenarioResultsView.tsx
+++ b/game/hud/src/components/ScenarioResults/components/ScenarioResultsView.tsx
@@ -82,9 +82,9 @@ const CloseOrnament = styled('div')`
 
 const CloseButtonPosition = css`
   position: absolute;
-  text-align:center;
+  text-align: center;
   top: 1px;
-  right: -9px;
+  right: 7px;
 `;
 
 export interface ScenarioResultsViewProps {

--- a/game/hud/src/components/SearchableList/index.tsx
+++ b/game/hud/src/components/SearchableList/index.tsx
@@ -96,16 +96,12 @@ class SearchableList extends React.Component<Props, State> {
   }
 
   public componentDidUpdate(prevProps: Props) {
-    if (!_.isEqual(this.props.listItemsData, prevProps.listItemsData) && this.props.searchValue === '') {
-      this.setState({ listItemsData: this.props.listItemsData });
-    }
-
     if (this.props.visible !== prevProps.visible) {
       this.setScrollTop();
     }
 
-    if (this.props.searchValue !== prevProps.searchValue) {
-      this.handleSearchChange();
+    if (this.props.searchValue !== prevProps.searchValue || !_.isEqual(this.props.listItemsData, prevProps.listItemsData) {
+      this.handleDataChange();
     }
   }
 
@@ -148,7 +144,7 @@ class SearchableList extends React.Component<Props, State> {
     }, 5);
   }
 
-  private handleSearchChange = () => {
+  private handleDataChange = () => {
     if (this.props.searchValue === '') {
       this.setState({ listItemsData: this.props.listItemsData });
     }

--- a/game/hud/src/components/SearchableList/index.tsx
+++ b/game/hud/src/components/SearchableList/index.tsx
@@ -169,10 +169,9 @@ class SearchableList extends React.Component<Props, State> {
   }
 
   private getVisibleItems = () => {
-    if (!this.scrollRef) return [];
-
     const { extraItemsRendered, listItemHeight, listHeight } = this.props;
-    const howManyItemsFit = Math.ceil((listHeight ||  this.scrollRef.clientHeight) / listItemHeight) +
+    const howManyItemsFit =
+      Math.ceil((listHeight || this.scrollRef ? this.scrollRef.clientHeight : 2160) / listItemHeight) +
       (extraItemsRendered || 0);
     const startingIndex = Math.floor(this.state.scrollTop / listItemHeight);
 


### PR DESCRIPTION
Fixes the things I reported here: https://forums.camelotunchained.com/topic/1522-2-part-testing-on-nuada-prep-saturday-september-8th-2018-italphabeta1/?do=findComment&comment=30783

Some previous changes had moved the close button outside of the close ornament. Changed the position so it is centered in the ornament again.

When the SearchabelList mounted this.scrollRef was undefined. Because of that getVisibleItems returned an empty array, which resulted in an empty list. 
Now, if listHeight exists it doesn't matter if this.scrollRef exists for proper calculations. If listHeight is not provided and this.scrollRef does not exist, we use a placeholder value for the clientHeight. To play it safe I am using the value of a 4k monitor resolution. This way I am rendering more items than I need to, when the component mounts, if listHeight is not provided.  I think this is far better than an empty list all the time. If the component rerenders this.scrollRef is defined and we no longer need the placeholder, so we no longer render too many items.

While testing I found one/two other problem. If SearchableList got new listItemsData via props listItemsData state was not updated, if a search value was set. If a search value existed it was not applied on the new listItemsData.
listItemsData state depends on listItemsData props and the search value. If one of them changes we need to update the state.