### PR TITLE
Various HUD Editor tweaks.

### DIFF
--- a/game/hud/src/components/HUD/HUDEditor.tsx
+++ b/game/hud/src/components/HUD/HUDEditor.tsx
@@ -74,7 +74,7 @@ class HUDEditor extends React.Component<Props, State> {
     super(props);
     this.state = {
       mode: EditMode.NONE,
-      editorPosition: { x: 2, y: 300 },
+      editorPosition: { x: 35, y: 150 },
       minScale: 0.5,
       maxScale: 3,
       scaleFactor: 0.01,
@@ -85,7 +85,6 @@ class HUDEditor extends React.Component<Props, State> {
     const { widgets } = this.props;
     return (
       <HUDEditorContainer
-        className='cse-ui-scroller-thumbonly'
         style={{
           right: `${this.state.editorPosition.x}px`,
           top: `${this.state.editorPosition.y}px`,
@@ -98,20 +97,28 @@ class HUDEditor extends React.Component<Props, State> {
             </a>
           </div>
         </HUDEditorTitle>
-        <HUDEditorList>
+        <HUDEditorList className='cse-ui-scroller-thumbonly'>
           <ul>
             { _.sortBy(widgets, 'name').map((widget) => {
+              const isVisible = widget.widget.position.visibility;
+              const isSelected = this.props.selectedWidget && this.props.selectedWidget.name === widget.name;
+              const classes = `HUDWidgetName${ isVisible ? '' : ' hidden' }${ isSelected ? ' selected' : '' }`;
               return (widget.name === 'building' ? null : // building should be removed as HUDDrag item
                 <li
                   key={widget.name}
                   onClick={() => {
                     this.props.setSelectedWidget(widget);
                   }}>
-                  <div className={
-                    this.props.selectedWidget && this.props.selectedWidget.name === widget.name ?
-                      'HUDWidgetNameSelected' : 'HUDWidgetName'
-                  }>
+                  <div className={ classes }
+                    onMouseOver={ isVisible ? null : this.onMouseOverListVisibility }
+                    onMouseLeave={ isVisible ? null : this.onMouseLeave }
+                  >
                     { widget.name === 'motd' ? 'MOTD' : _.startCase(widget.name) }
+                    {/* { !isVisible &&
+                      <span>&nbsp;<i
+                        className={'fa fa-eye-slash'}
+                      ></i></span>
+                    } */}
                   </div>
                 </li>
               );
@@ -425,6 +432,12 @@ class HUDEditor extends React.Component<Props, State> {
         layoutMode: widget.position.layoutMode,
       },
     }));
+  }
+
+  private onMouseOverListVisibility = (e: React.MouseEvent<HTMLElement>) => {
+    this.tooltipMessage = 'Widget is Hidden';
+    this.tooltipEvent = e;
+    this.onMouseOver(e);
   }
 
   private onMouseOverToggleVisibility = (e: React.MouseEvent<HTMLElement>) => {

--- a/game/hud/src/components/HUD/style.ts
+++ b/game/hud/src/components/HUD/style.ts
@@ -9,7 +9,7 @@ import styled, { css } from 'react-emotion';
 export const HUDEditorContainer = styled('div')`
   position: fixed;
   width: 200px;
-  height: 400px;
+  height: 35%;
   overflow-x: hidden;
   overflow-y: hidden;
   color: white;
@@ -67,7 +67,7 @@ export const HUDEditorList = styled('div')`
   ul {
     li {
       background: #191919;
-      margin-bottom: 4px;
+      margin-bottom: 1px;
       margin-right: 20px;
       -webkit-transition: all 0.5s ease;
       div {
@@ -76,22 +76,23 @@ export const HUDEditorList = styled('div')`
         pointer-events: all;
       }
       div.HUDWidgetName {
-        background: #191919;
-        color: #93866c;
+        background: #120c08;
+        color: #a08f68;
+        border: 1px solid #000000;
         width: 100%;
         cursor: pointer;
       }
-      div.HUDWidgetNameSelected {
-        background: #191919;
-        background-color: #91743a;
+      div.hidden {
+        background: #15130c;
+        color: #564f40;
+      }
+      div.selected {
+        border: 1px solid #91743a;
         color: #fff;
-        width: 100%;
       }
       &:hover {
-        background: #191919;
-        -webkit-transition: all 0.5s ease;
         div.HUDWidgetName {
-          background: #93866c;
+          // border: 1px solid #93866c;
           color: #fff;
         }
       }

--- a/game/hud/src/components/HUDDrag/index.scss
+++ b/game/hud/src/components/HUDDrag/index.scss
@@ -5,6 +5,7 @@
  */
 
 .HUDDrag {
+
 }
 
 .HUDDrag__controls {
@@ -20,6 +21,14 @@
 }
 
 .HUDDrag__controlsSelected {
+  @keyframes pulseBorder {
+    0%,100% {
+      box-shadow: 0px 0px 0px 3px rgba(145, 116, 58, 1);
+    }
+    50% {
+      box-shadow: 0px 0px 0px 3px rgba(145, 116, 58, 0.4);
+    }
+  }
   @-webkit-keyframes pulseBorder {
     0%,100% {
       box-shadow: 0px 0px 0px 3px rgba(145, 116, 58, 1);
@@ -46,6 +55,14 @@
 }
 
 .HUDDrag__controls__nameSelected {
+  @keyframes pulseBackground {
+    0%,100% {
+      background: rgba(145, 116, 58, 1);
+    }
+    50% {
+      background: rgba(145, 116, 58, 0.4);
+    }
+  }
   @-webkit-keyframes pulseBackground {
     0%,100% {
       background: rgba(145, 116, 58, 1);
@@ -109,171 +126,4 @@
   margin: -20px 0px 0px 0px;
   bottom: -5px;
   right: -5px;
-}
-
-
-.HUDDrag__controls__scaleHandle {
-  position: absolute;
-  width: 10px;
-  height: 20px;
-  right: 20px;
-  top: 50%;
-  margin-top: -30px;
-  cursor: zoom-in !important;
-  background: blue;
-  &:before {
-    content: '';
-    position: absolute;
-    width: 0;
-    height: 0;
-    top: -24px;
-    left: -5px;
-    border: 10px solid transparent;
-    border-bottom: 15px solid blue;
-  }
-  &:after {
-    content: '';
-    position: absolute;
-    width: 0;
-    height: 0;
-    bottom: -24px;
-    left: -5px;
-    border: 10px solid transparent;
-    border-top: 15px solid blue;
-  }
-}
-
-.HUDDrag__controls__scaleHandle--up {
-  &:before {
-    content: '';
-    border-color:transparent;
-    border-style:solid;
-    position: absolute;
-    border: none;
-    background-color: cornflowerblue;
-    height: 50%;
-    width: 50%;
-    top: 25%;
-    left: 50%;
-    margin-left: -25%;
-  }
-  &:after {
-    content: '';
-    position: absolute;
-    border-left: 10px solid transparent;
-    border-right: 10px solid transparent;
-    border-bottom: 10px solid cornflowerblue;
-  }
-}
-
-.HUDDrag__controls__scaleHandle--down {
-  &:before {
-    content: '';
-    border-color:transparent;
-    border-style:solid;
-    position: absolute;
-    border: none;
-    background-color: cornflowerblue;
-    height: 50%;
-    width: 50%;
-    bottom: 25%;
-    left: 50%;
-    margin-left: -25%;
-  }
-  &:after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    border-left: 10px solid transparent;
-    border-right: 10px solid transparent;
-    border-top: 10px solid cornflowerblue;
-  }
-}
-
-.HUDDrag__controls__scaleText {
-  position: relative;
-  top: 28px;
-  padding: 2px;
-  text-align: center;
-  color: white;
-  font-size: .5em;
-  border-radius: 15px;
-  cursor: default !important;
-}
-
-.HUDDrag__controls__toolbar {
-  position: fixed;
-  right: 0px;
-  top: 50px;
-  width: 140px;
-  color: #93866c;
-  z-index: 9999 !important;
-  a {
-    color: #93866c;
-    text-decoration: none;
-    -webkit-transition: all 0.5s;
-    transition: all 0.5s;
-    -webkit-animation: none;
-    animation: none;
-    &:hover {
-      color: white;
-      -webkit-animation: glow 1.5s ease-in-out infinite alternate;
-      animation: glow 1.5s ease-in-out infinite alternate;
-    }
-  }
-}
-
-.HUDDrag__controls__toolbar__scale {
-  position: relative;
-  display: inline-block;
-  width: 70px;
-  height: 50px;
-  font-size: 1.2rem;
-  text-align: center;
-  // margin-bottom: 10px;
-  i {
-    position: relative;
-  }
-}
-
-.HUDDrag__controls__toolbar__dragControl {
-  position: absolute;
-  width: 100%;
-  height: 25px;
-  top: 0;
-  left: 0;
-  cursor: row-resize !important;
-}
-
-.HUDDrag__controls__toolbar__scale__controls {
-  position: absolute;
-  bottom: 15px;
-  left: 0;
-  width: 100%;
-  height: 15px;
-  div {
-    display: inline-block;
-    text-align: center;
-    width: 50%;
-    height: 15px;
-    font-size: 1em;
-    line-height: 15px;
-    cursor: pointer !important;
-  }
-}
-
-.HUDDrag__controls__toolbar__visibility {
-  position: relative;
-  display: inline-block;
-  width: 50px;
-  height: 50px;
-  font-size: 1.5rem;
-  text-align: center;
-  padding-top: 20px;
-  padding-left: 20px;
-  margin-bottom: 10px;
-  i {
-    position: relative;
-    cursor: pointer !important;
-  }
 }

--- a/game/hud/src/components/HUDDrag/index.tsx
+++ b/game/hud/src/components/HUDDrag/index.tsx
@@ -188,7 +188,7 @@ class HUDDrag extends React.Component<HUDDragProps, HUDDragState> {
           left: `${position.x}px`,
           top: `${position.y}px`,
           pointerEvents: 'none',
-          zIndex: this.props.zOrder,
+          zIndex: !this.props.locked && this.props.selected ? 999 : this.props.zOrder,
           ...scale,
         }}>
           <div style={{

--- a/game/hud/src/services/session/layout.ts
+++ b/game/hud/src/services/session/layout.ts
@@ -311,6 +311,7 @@ export function initialize() {
         case 'chat':
           return dispatch(toggleVisibility(name));
         case 'ui': return dispatch(toggleHUDLock(addEvent, removeEvent));
+        case 'lockui': return dispatch(lockHUD(removeEvent));
         case 'reset': return dispatch(resetHUD());
         default: return;
       }

--- a/game/hud/src/services/session/layoutItems/HUDNav.tsx
+++ b/game/hud/src/services/session/layoutItems/HUDNav.tsx
@@ -20,6 +20,7 @@ const hideClientControlledUI = () => {
   client.HideUI('inventory');
   client.HideUI('equippedgear');
   client.HideUI('plotcontrol');
+  events.fire('hudnav--navigate', 'lockui');
 };
 
 export default {
@@ -122,6 +123,7 @@ export default {
         onClick: () => {
           events.fire('hudnav--navigate', 'equippedgear-left');
           events.fire('hudnav--navigate', 'inventory-right');
+          hideClientControlledUI();
         },
       },
       {
@@ -137,6 +139,7 @@ export default {
         onClick: () => {
           events.fire('hudnav--navigate', 'equippedgear-left');
           events.fire('hudnav--navigate', 'inventory-right');
+          hideClientControlledUI();
         },
       },
       // {
@@ -339,20 +342,20 @@ export default {
           events.fire('hudnav--navigate', 'ui');
         },
       },
-      {
-        name: 'reset',
-        tooltip: 'Reset UI layout',
-        iconClass: 'fa-clone',
-        icon: (
-          <span>
-            <i className='fa fa-clone fa-stack-1x fa-inverse'></i>
-          </span>
-        ),
-        hidden: false,
-        onClick: () => {
-          events.fire('hudnav--navigate', 'reset');
-        },
-      },
+      // {
+      //   name: 'reset',
+      //   tooltip: 'Reset UI layout',
+      //   iconClass: 'fa-clone',
+      //   icon: (
+      //     <span>
+      //       <i className='fa fa-clone fa-stack-1x fa-inverse'></i>
+      //     </span>
+      //   ),
+      //   hidden: false,
+      //   onClick: () => {
+      //     events.fire('hudnav--navigate', 'reset');
+      //   },
+      // },
       {
         name: 'reloadui',
         tooltip: 'Reload UI',


### PR DESCRIPTION
This PR fixes some of the issues with the current HUD Editor:
- Changes default HUD Editor position, to a location where the Bug Report button doesn't overlap the scrollbar.
- Fixes the scrollbar not using the CU decorations.
- Greys out items in the HUD Editor list, if a widget is hidden.
- Remove UI Reset button from HUDNav (since it is now in the HUD Editor).
- Lock the UI if any of the fullscreen UI's are opened.

Still to-do:
- Add a button to the HUD Editor that exits edit mode (locks the UI).
- Change style of widget titlebar/border, when widget is hidden.