### PR TITLE
fix compass warband poi

### DIFF
--- a/game/hud/src/components/Compass/POI/WarbandMembersPoiProvider.tsx
+++ b/game/hud/src/components/Compass/POI/WarbandMembersPoiProvider.tsx
@@ -248,6 +248,23 @@ export default class WarbandMembersPoiProvider extends React.Component<
   public onWarbandMemberUpdated = (rawNewMemberState: string) => {
     const newMemberState: GroupMemberState = JSON.parse(rawNewMemberState);
     if (newMemberState.characterID !== client.characterID) {
+      if (
+        this.state.characterIdToIdMap[newMemberState.characterID] &&
+        newMemberState.id !== this.state.characterIdToIdMap[newMemberState.characterID]
+      ) {
+        this.props.compass.removePOI(
+          'warband',
+          `warband-${this.state.characterIdToIdMap[newMemberState.characterID]}`,
+        );
+      }
+      this.setState((prevState: WarbandMembersPoiProviderState) => {
+        return {
+          characterIdToIdMap: {
+            ...prevState.characterIdToIdMap,
+            [newMemberState.characterID]: newMemberState.id,
+          },
+        };
+      });
       this.props.compass.updatePOI('warband', this.getWarbandMemberPOI(newMemberState));
     }
   }
@@ -255,6 +272,15 @@ export default class WarbandMembersPoiProvider extends React.Component<
   public onWarbandMemberJoined = (rawNewMemberState: string) => {
     const newMemberState: GroupMemberState = JSON.parse(rawNewMemberState);
     if (newMemberState.characterID !== client.characterID) {
+      if (
+        this.state.characterIdToIdMap[newMemberState.characterID] &&
+        newMemberState.id !== this.state.characterIdToIdMap[newMemberState.characterID]
+      ) {
+        this.props.compass.removePOI(
+          'warband',
+          `warband-${this.state.characterIdToIdMap[newMemberState.characterID]}`,
+        );
+      }
       this.setState((prevState: WarbandMembersPoiProviderState) => {
         return {
           characterIdToIdMap: {


### PR DESCRIPTION
This hopefully fixes an issue with compass warband member POI duplicates.

There is a thread on forums for this: https://forums.camelotunchained.com/topic/1531-compass-shows-group-member-at-two-different-positions/

---

This **Needs** testing in client before merging.