### PR TITLE
Correct compile time warnings generated for *TargetState models

### DIFF
--- a/library/src/game/initGameInterface.ts
+++ b/library/src/game/initGameInterface.ts
@@ -16,8 +16,8 @@ import initEventForwarding from './engineEvents';
 import initLoadingState from './GameClientModels/LoadingState';
 import initPlayerState from './GameClientModels/PlayerState';
 import initEntityState from './GameClientModels/EntityState';
-import initEnemytargetState from './GameClientModels/EnemytargetState';
-import initFriendlytargetState from './GameClientModels/FriendlytargetState';
+import initEnemyTargetState from './GameClientModels/EnemyTargetState';
+import initFriendlyTargetState from './GameClientModels/FriendlyTargetState';
 import initKeyActions from './GameClientModels/KeyActions';
 import initAbilityState from './GameClientModels/AbilityState';
 import initAbilityBarState from './GameClientModels/AbilityBarState';
@@ -72,8 +72,8 @@ export default function(isAttached: boolean) {
   // INIT MODELS
   initLoadingState();
   initPlayerState();
-  initEnemytargetState();
-  initFriendlytargetState();
+  initEnemyTargetState();
+  initFriendlyTargetState();
   initKeyActions();
   initAbilityState();
   initAbilityBarState();


### PR DESCRIPTION
Example of the warning being generated.

```
WARNING in D:/dev/CU/Mehuge/Camelot-Unchained/library/lib/game/GameClientModels/EnemyTargetState.js
There are multiple modules with names that only differ in casing.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Use equal casing. Compare these module identifiers:
* D:\dev\CU\Mehuge\Camelot-Unchained\node_modules\babel-loader\lib\index.js??ref--4-oneOf-1-0!D:\dev\CU\Mehuge\Camelot-Unchained\library\lib\game\GameClientModels\EnemyTargetState.js
    Used by 1 module(s), i. e.
    D:\dev\CU\Mehuge\Camelot-Unchained\node_modules\babel-loader\lib\index.js??ref--4-oneOf-1-0!D:\dev\CU\Mehuge\Camelot-Unchained\library\lib\game\GameClientModels\index.js
* D:\dev\CU\Mehuge\Camelot-Unchained\node_modules\babel-loader\lib\index.js??ref--4-oneOf-1-0!D:\dev\CU\Mehuge\Camelot-Unchained\library\lib\game\GameClientModels\EnemytargetState.js
    Used by 1 module(s), i. e.
    D:\dev\CU\Mehuge\Camelot-Unchained\node_modules\babel-loader\lib\index.js??ref--4-oneOf-1-0!D:\dev\CU\Mehuge\Camelot-Unchained\library\lib\game\initGameInterface.js
```

From that I was able to determine the issue was in initGameInterface.ts. This change removes two such warnings.

There are some other module case warnings, but I have not figured out what is causing those.