### PR TITLE
fix security issue for event-stream

### DIFF
--- a/game/hud/package.json
+++ b/game/hud/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
     "@babel/runtime": "^7.0.0-rc.1",
-    "@csegames/camelot-unchained": "^0.1.64",
+    "@csegames/camelot-unchained": "^0.2.0",
     "aphrodite": "^1.1.0",
     "apollo": "^1.7.0",
     "apollo-client": "^1.9.0-1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5360,11 +5360,10 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
 event-stream@~3.3.0:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.6.tgz#cac1230890e07e73ec9cacd038f60a5b66173eef"
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.5.tgz#e5dd8989543630d94c6cf4d657120341fa31636b"
   dependencies:
     duplexer "^0.1.1"
-    flatmap-stream "^0.1.0"
     from "^0.1.7"
     map-stream "0.0.7"
     pause-stream "^0.0.11"
@@ -5816,10 +5815,6 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
-
-flatmap-stream@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/flatmap-stream/-/flatmap-stream-0.1.0.tgz#ed54e01422cd29281800914fcb968d58b685d5f1"
 
 flush-write-stream@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
This is an **important** fix to get yarn working again. Is due to security issue with `event-stream` package..

https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident