### PR TITLE
move FilterSelectMenu on top of the inventory items 

### DIFF
--- a/game/hud/src/widgets/HUDFullScreen/components/Inventory/components/InventoryHeader.tsx
+++ b/game/hud/src/widgets/HUDFullScreen/components/Inventory/components/InventoryHeader.tsx
@@ -23,7 +23,7 @@ const Container = styled('div')`
   padding: 10px 10px 5px 10px;
   background: url(images/inventory/bag-bg.png);
   background-size: cover;
-  z-index: 1;
+  z-index: 2;
   &:before {
     content: '';
     position: absolute;


### PR DESCRIPTION
fixing [this](https://forums.camelotunchained.com/topic/1922-item-stack-count-is-in-front-of-filter-edit-menu/) bug