### PR TITLE
Fix UI Crash when unbinding a key

### DIFF
--- a/game/hud/src/widgets/Settings/components/KeybindRow.tsx
+++ b/game/hud/src/widgets/Settings/components/KeybindRow.tsx
@@ -170,13 +170,12 @@ export class KeybindRow extends React.Component<Props, State> {
     let content: JSX.Element = null;
     switch (this.state.mode) {
       case KeybindMode.Idle: return null;
-      case KeybindMode.ListeningForKey: {
+      case KeybindMode.ListeningForKey:
         content = (
           <ListeningDialog keybind={this.state.keybind} onRemoveBind={this.onRemoveBind} onClose={this.cancel} />
         );
-      }
         break;
-      case KeybindMode.ConfirmBind: {
+      case KeybindMode.ConfirmBind:
         const conflicts = checkForConflicts(this.state.keybind.id, this.state.newBind);
         content = (
           <ConfirmBindDialog
@@ -188,7 +187,6 @@ export class KeybindRow extends React.Component<Props, State> {
             onNoClick={this.cancel}
           />
         );
-      }
         break;
     }
 
@@ -217,6 +215,7 @@ export class KeybindRow extends React.Component<Props, State> {
   }
 
   private onRemoveBind = () => {
+    this.cancel();                  // we were listening, need to cancel
     this.setState((state) => {
       const newState = {
         ...state,
@@ -259,6 +258,7 @@ export class KeybindRow extends React.Component<Props, State> {
   private cancel = () => {
     if (this.listenPromise) {
       this.listenPromise.cancel();
+      this.listenPromise = null;
     }
     this.setState({
       mode: KeybindMode.Idle,

--- a/game/hud/src/widgets/Settings/components/KeybindRow.tsx
+++ b/game/hud/src/widgets/Settings/components/KeybindRow.tsx
@@ -143,8 +143,11 @@ export class KeybindRow extends React.Component<Props, State> {
   }
 
   public shouldComponentUpdate(nextProps: Props, nextState: State) {
-    for (let i = 0; i < nextState.keybind.binds.length; ++i) {
-      if (this.state.keybind.binds[i].value !== nextState.keybind.binds[i].value) {
+    const binds = this.state.keybind.binds;
+    const nextBinds = nextState.keybind.binds;
+    for (let i = 0; i < nextBinds.length; ++i) {
+      if (binds[i] !== nextBinds[i]) return true;
+      if (binds[i] && binds[i].value !== nextBinds[i].value) {
         return true;
       }
     }


### PR DESCRIPTION
This PR fixes an issue whereby the UI crashes when trying to unbind a key.

I also changed `gameTasks` to handle cancelled better.  A cancelled promise will not trigger a resolve, but if the game engine does resolve it when its been cancelled, the promise is rejected with `{ cancelled: true }`.

Also added debugs to `gameTasks` (under game.debug) as cancelling the keybind listener is not working, I suspect its not the promise code, but rather the listener code, in which case the debugs can be removed again.  

Also, when removing a keybind, the code did not attempt to cancel the listener, it should.