### PR TITLE
Scenario Join/Leave improvements

### DIFF
--- a/game/hud/src/services/session/scenarioQueue.ts
+++ b/game/hud/src/services/session/scenarioQueue.ts
@@ -84,19 +84,23 @@ function onerror(reason: GraphQLQueryResult<any>) {
   console.error(reason);
 }
 
-function poll() {
+export function poll() {
   gqlQuery(scenarioQuery).then(onload, onerror);
 }
 
-// Incrememnt watchers, cancel current poll interval and start a new one.
-// This is so that the thing calling start gets the latest information now
-// rather than on next poll. We also return the current scenario data
-// immediately if we have any.
-export function startPollingScenarioQueue() {
-  watchers++;
+// Cancel current poll interval and start a new one. Sometimes we just want to get the
+// information now, not in N seconds time.
+export function pollNow() {
   if (timer) clearInterval(timer);
   poll();
   timer = setInterval(poll, 10000);
+}
+
+// Incrememnt watchers, and also return the current scenario data
+// immediately if we have any.
+export function startPollingScenarioQueue() {
+  watchers++;
+  pollNow();
   return scenarios;
 }
 

--- a/game/hud/src/widgets/ScenarioButton/index.tsx
+++ b/game/hud/src/widgets/ScenarioButton/index.tsx
@@ -15,6 +15,7 @@ import {
   startPollingScenarioQueue,
   stopPollingScenarioQueue,
   scenarioIsAvailable,
+  pollNow,
 } from 'services/session/scenarioQueue';
 
 const Container = styled('div')`
@@ -26,6 +27,7 @@ const IconMenu = styled('div')`
 
 const IconButton = styled('div')`
   ${CSS.ALLOW_MOUSE}
+  position: relative;
   box-sizing: border-box!important;
   width: 36px;
   height: 36px;
@@ -55,6 +57,9 @@ const IconButton = styled('div')`
     color: #cbcbcb;
     background-image: url(images/settings/button-off.png);
   }
+  &.not-available {
+    filter: grayscale(100%);
+  }
 `;
 
 const Icon = styled('div')`
@@ -72,7 +77,7 @@ const ToolTip = styled('div')`
   position: absolute;
   top: 0;
   right: 40px;
-  width: 200px;
+  width: 350px;
   height: 70px;
   z-index: 32000;
 `;
@@ -92,7 +97,7 @@ const ToolTipTitle = styled('div')`
   position: absolute;
   top: 15px;
   left: 20px;
-  font-size: 15px;
+  font-size: 13px;
   color: #f5d797;
   text-transform: uppercase;
   letter-spacing: 3px;
@@ -178,16 +183,19 @@ export class ScenarioButton extends React.Component<Props, State> {
         <IconButton className={cls.join(' ')} onClick={this.click}/>
         { open && (
           <IconMenu>
-            { scenarios.map((scenario, index) => (
-                <IconButton onMouseOver={this.hover} onMouseOut={this.hover}
-                  onClick={scenario.isQueued ? () => this.leaveQueue(scenario.id) : () => this.joinQueue(scenario.id)}>
+            { scenarios.map((scenario, index) => {
+              return (
+                <IconButton
+                  className={scenarioIsAvailable(scenario) ? '' : 'not-available'}
+                  onMouseOver={this.hover} onMouseOut={this.hover}
+                  onClick={(scenario.isQueued ? () => this.leaveQueue(scenario.id) : () => this.joinQueue(scenario.id))}>
                   <Icon
                     ref={(node: any) => this.nodes[index] = ReactDOM.findDOMNode(node)}
                     style={{ backgroundImage: `url(${scenario.icon})` }}
                     />
                 </IconButton>
-              ))
-            }
+              );
+            })}
           </IconMenu>
         )}
       </Container>
@@ -195,13 +203,23 @@ export class ScenarioButton extends React.Component<Props, State> {
   }
 
   private joinQueue = (id: string) => {
-    game.webAPI.ScenarioAPI.AddToQueue(game.webAPI.defaultConfig, game.shardID, game.selfPlayerState.characterID,
-    id);
+    game.webAPI.ScenarioAPI.AddToQueue(
+      game.webAPI.defaultConfig,
+      game.shardID,
+      game.selfPlayerState.characterID,
+      id,
+    );
+    setTimeout(pollNow, 2000);
   }
 
   private leaveQueue = (id: string) => {
-    game.webAPI.ScenarioAPI.RemoveFromQueue(game.webAPI.defaultConfig, game.shardID, game.selfPlayerState.characterID,
-    id);
+    game.webAPI.ScenarioAPI.RemoveFromQueue(
+      game.webAPI.defaultConfig,
+      game.shardID,
+      game.selfPlayerState.characterID,
+      id,
+    );
+    setTimeout(pollNow, 2000);
   }
 
   private click = () => {


### PR DESCRIPTION
Joining/Leaving improvements to feedback and responsiveness.

Attempt to improve the responsiveness of joining/leaving scenario queues. The time taken to join a queue from the point of sending the request to join varies, can be longer than two seconds.  However, the UI waits for the next poll interval to update, which could be 10 seconds away.

When joining/leaving a queue, wait 2 seconds the poll for new data (we effectively bring the poll tick forward to now + 2 seconds).  This allows enough time (in most cases) for the player to have joined the queue, but not too long that it seems to be stuck.

Added immediate feedback to the Find Match / Leave Queue buttons, they now say 'Joining...' or 'Leaving...' whilst the join/leave request is pending.  This gives immediate feedback that it is at least trying to join/leave the queue.

Eventually, subscription based notifications (has-joined-queue) would help make the user interface feel more responsive. 