### PR TITLE
Improved scenario status messaging

### DIFF
--- a/game/hud/src/widgets/ScenarioJoin/components/Scenario.tsx
+++ b/game/hud/src/widgets/ScenarioJoin/components/Scenario.tsx
@@ -95,7 +95,7 @@ export class Scenario extends React.PureComponent<ScenarioProps, ScenarioState> 
     let status;
     let needed;
     if (needed = scenarioIsAvailable(scenario)) {
-      status = `PLAYERS NEEDED TO START NEXT GAME:\n`
+      status = `PLAYERS ${scenario.gamesInProgress ? `ARE STILL NEEDED FOR THIS` : `NEEDED TO START NEXT`} GAME:\n`
         + `${needed.tdd} TDD / ${needed.viking} VKK / ${needed.arthurian} ART`;
     } else {
       status = 'Scenario Not Available';


### PR DESCRIPTION
Fixes the scenario status message so that when a game is running, it says

PLAYERS ARE STILL NEEDED FOR THIS GAME

rather than the current

PLAYERS NEEDED TO START NEXT GAME

Not tested, because Nuada won't let me run non-stock UIs.