### PR TITLE
trigger the shine effect, when the progress bar is at 100%

### DIFF
--- a/game/hud/src/components/LoadingScreen/ProgressBar.tsx
+++ b/game/hud/src/components/LoadingScreen/ProgressBar.tsx
@@ -93,13 +93,32 @@ export interface Props {
   progress: number;
 }
 
-// tslint:disable-next-line:function-name
-export function ProgressBar(props: Props) {
-  return (
-    <BarContainer>
-      <ProgressText>{props.progress}%</ProgressText>
-      <Bar style={{ left: `${-(100 - props.progress)}%` }} />
-      {props.progress === 100 && <ButtonShine />}
-    </BarContainer>
-  );
+export interface State {
+  shine: boolean;
+}
+
+export class ProgressBar extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { shine: false };
+  }
+
+  public render() {
+    const props = this.props;
+    if (props.progress === 100 && !this.state.shine) {
+      window.addEventListener('transitionend', this.transitionEnd);
+    }
+    return (
+      <BarContainer>
+        <ProgressText>{props.progress}%</ProgressText>
+        <Bar style={{ left: `${-(100 - props.progress)}%` }} />
+        {this.state.shine && <ButtonShine />}
+      </BarContainer>
+    );
+  }
+
+  private transitionEnd = () => {
+    this.setState({ shine: true });
+    window.removeEventListener('transitionend', this.transitionEnd);
+  }
 }

--- a/library/src/game/mock/mockLoading.ts
+++ b/library/src/game/mock/mockLoading.ts
@@ -141,7 +141,7 @@ function loadingRun() {
     return;
   }
 
-  _devGame.loadingState.percent += 1;
+  _devGame.loadingState.percent += 20;
   _devGame.loadingState.message = loadingMessages[Math.floor(Math.random() * loadingMessages.length)];
   console.log('MOCK.loadingState', `run - ${game.loadingState.percent}% ${game.loadingState.message}`);
   engine.trigger(LoadingState_Update, game.loadingState);


### PR DESCRIPTION
**not tested in the client!!!** I couldn't find a server, that allows a custom UI.

The problem:
When the test for the progress bar were done, the progress was increased by 1% each step. Currently in the client the progress increases by 20% each step. This makes something visible you could not see before. 

When props.progress is at 100(%), the progress bar is still one step before 100% and starts its transition to 100%. If you increase props.progress by 1%, one step before 100% is 99%. If you increase it by 20%, the progress bar is at 80%, when props.progress is at 100. But if props.progress is at 100, the shine effect start.
If the progress bar is at 99%, when the shine effect starts, everything is ok. 
In the other case the progress bar actually is at 80%, when the shine effect starts.
It beginns outside of the progress bar. It looks more like bug than a shine effect on the progress bar.

I have changed the code. If props.progress is at 100 I am adding an event listener now. It gets triggered, when the transition is completed, which means the progress bar has actually reached 100%.

It works in a Chrome Browser.

I don't know if it works with Coherent and if  "transitionend" is the correct event for Coherent.