### PR TITLE
update content and style of the tooltip, if its parent element did update…

### DIFF
--- a/game/hud/src/components/fullscreen/Crafting/components/JobPanel/JobPanelPageView.tsx
+++ b/game/hud/src/components/fullscreen/Crafting/components/JobPanel/JobPanelPageView.tsx
@@ -216,7 +216,7 @@ const InputSection = styled.div`
 
 const OutputContainer = styled.div`
   flex: 1;
-  z-index: 13
+  z-index: 13;
   pointer-events: none;
 `;
 

--- a/game/hud/src/components/shared/Tooltip.tsx
+++ b/game/hud/src/components/shared/Tooltip.tsx
@@ -11,9 +11,12 @@ import {
   onShowTooltip,
   onHideTooltip,
   ShowTooltipPayload,
+  UpdateTooltipPayload,
   ToolTipStyle,
   showTooltip,
   hideTooltip,
+  onUpdateTooltip,
+  updateTooltip,
 } from 'actions/tooltips';
 import { getViewportSize } from 'lib/viewport';
 
@@ -167,6 +170,7 @@ export class TooltipView extends React.Component<{}, TooltipState> {
     window.addEventListener('mousemove', this.onMouseMove);
     this.eventHandles.push(onShowTooltip(this.handleShowTooltip));
     this.eventHandles.push(onHideTooltip(this.handleHideTooltip));
+    this.eventHandles.push(onUpdateTooltip(this.handleUpdateTooltip));
   }
   public componentWillUnmount() {
     window.removeEventListener('mousemove', this.onMouseMove);
@@ -217,6 +221,15 @@ export class TooltipView extends React.Component<{}, TooltipState> {
       styles,
       shouldAnimate,
     });
+  }
+  private handleUpdateTooltip = (payload: UpdateTooltipPayload) => {
+    if (this.state.show) {
+      const { content, styles } = payload;
+      this.setState({
+        content,
+        styles,
+      });
+    }
   }
   private handleHideTooltip = () => {
     this.setState({ show: false, content: null, styles: {} });
@@ -272,6 +285,10 @@ export class Tooltip extends React.PureComponent<TooltipProps, {}> {
     this.handleMouseLeave();
   }
 
+  public componentDidUpdate() {
+    this.handleUpdateTooltip();
+  }
+
   private handleMouseOver = (event: React.MouseEvent) => {
     if (this.isMouseOver) return;
     this.isMouseOver = true;
@@ -306,6 +323,13 @@ export class Tooltip extends React.PureComponent<TooltipProps, {}> {
         }));
       });
     }
+  }
+  private handleUpdateTooltip = () => {
+    if (!this.isMouseOver) return;
+    updateTooltip({
+      content: this.props.content,
+      styles: this.props.styles,
+    });
   }
   private handleMouseLeave = () => {
     if (!this.isMouseOver) return;

--- a/game/hud/src/services/actions/tooltips.ts
+++ b/game/hud/src/services/actions/tooltips.ts
@@ -8,6 +8,7 @@
 // BASIC MANAGEMENT
 
 export const ACTIVATE_TOOLTIP = 'active-tooltip';
+export const UPDATE_TOOLTIP = 'update-tooltip';
 export const HIDE_TOOLTIP = 'hide-tooltip';
 
 export interface ToolTipStyle {
@@ -26,8 +27,17 @@ export interface ShowTooltipPayload {
   styles?: Partial<ToolTipStyle>;
 }
 
+export interface UpdateTooltipPayload {
+  content: JSX.Element | JSX.Element[] | string;
+  styles?: Partial<ToolTipStyle>;
+}
+
 export function showTooltip(payload: ShowTooltipPayload) {
   game.trigger(ACTIVATE_TOOLTIP, payload);
+}
+
+export function updateTooltip(payload: UpdateTooltipPayload) {
+  game.trigger(UPDATE_TOOLTIP, payload);
 }
 
 export function hideTooltip() {
@@ -36,6 +46,10 @@ export function hideTooltip() {
 
 export function onShowTooltip(callback: (payload: ShowTooltipPayload) => void) {
   return game.on(ACTIVATE_TOOLTIP, callback);
+}
+
+export function onUpdateTooltip(callback: (payload: UpdateTooltipPayload) => void) {
+  return game.on(UPDATE_TOOLTIP, callback);
 }
 
 export function onHideTooltip(callback: () => void) {


### PR DESCRIPTION
…, so the tooltip matches the values of the element, that displayed it.

If the parent element rerenders, the tooltip is rerendered as well, but the state of the tooltip view was not updated. If the parent element (and the tooltip) did update there is a checked now, if the mouse is over the parent. Only in this case an update event is triggered. If the tooltip view is visible, it's state (content and style) is updated based on the data from the event and the tooltip matches the data of the parent element again.

This solves the problem reported [here](https://forums.camelotunchained.com/topic/2495-playerframe-tooltip-does-not-update/)